### PR TITLE
Save object instances when handling one to many relations

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,7 @@ Development
 - Add validation to `_fill_optional` parameter
 - Add new `_from_manager` parameter to `make` method
 - Clean up obsolete imports
+- Save object instances when handling one to many relations
 
 1.6.0
 -----

--- a/model_mommy/mommy.py
+++ b/model_mommy/mommy.py
@@ -414,7 +414,12 @@ class Mommy(object):
     def _handle_one_to_many(self, instance, attrs):
         for k, v in attrs.items():
             manager = getattr(instance, k)
-            manager.set(v, clear=True)
+
+            try:
+                manager.set(v, bulk=False, clear=True)
+            except TypeError:
+                # for many-to-many relationships the bulk keyword argument doesn't exist
+                manager.set(v, clear=True)
 
     def _handle_m2m(self, instance):
         for key, values in self.m2m_dict.items():

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -118,6 +118,12 @@ class GuardDog(Dog):
     pass
 
 
+class Home(models.Model):
+    address = models.CharField(max_length=200)
+    owner = models.ForeignKey('Person', on_delete=models.CASCADE)
+    dogs = models.ManyToManyField('Dog')
+
+
 class LonelyPerson(models.Model):
     only_friend = models.OneToOneField(Person, on_delete=models.CASCADE)
 

--- a/tests/test_mommy.py
+++ b/tests/test_mommy.py
@@ -236,6 +236,20 @@ class MommyCreatesAssociatedModels(TestCase):
         except TypeError:
             self.fail('type error raised')
 
+    def test_save_object_instances_when_handling_one_to_many_relations(self):
+        owner = mommy.make(models.Person)
+        dogs_set = mommy.prepare(
+            models.Dog,
+            owner=owner,
+            _quantity=2,
+        )
+        home = mommy.make(
+            models.Home,
+            owner=owner,
+            dogs=dogs_set,
+        )
+        self.assertEqual(home.dogs.count(), 2)
+
     def test_prepare_fk(self):
         dog = mommy.prepare(models.Dog)
         self.assertIsInstance(dog, models.Dog)

--- a/tests/test_mommy.py
+++ b/tests/test_mommy.py
@@ -246,7 +246,7 @@ class TestMommyCreatesAssociatedModels():
             owner=owner,
             dogs=dogs_set,
         )
-        self.assertEqual(home.dogs.count(), 2)
+        assert home.dogs.count() == 2
         assert 2 == models.Dog.objects.count()  # dogs in dogs_set were created
 
     def test_prepare_fk(self):

--- a/tests/test_mommy.py
+++ b/tests/test_mommy.py
@@ -240,6 +240,7 @@ class MommyCreatesAssociatedModels(TestCase):
         owner = mommy.make(models.Person)
         dogs_set = mommy.prepare(
             models.Dog,
+            owner=owner,
             _quantity=2,
         )
         home = mommy.make(

--- a/tests/test_mommy.py
+++ b/tests/test_mommy.py
@@ -240,7 +240,6 @@ class MommyCreatesAssociatedModels(TestCase):
         owner = mommy.make(models.Person)
         dogs_set = mommy.prepare(
             models.Dog,
-            owner=owner,
             _quantity=2,
         )
         home = mommy.make(

--- a/tests/test_mommy.py
+++ b/tests/test_mommy.py
@@ -243,12 +243,15 @@ class MommyCreatesAssociatedModels(TestCase):
             owner=owner,
             _quantity=2,
         )
+
+        assert 0 == models.Dog.objects.count()  # ensure there're no dogs in our db
         home = mommy.make(
             models.Home,
             owner=owner,
             dogs=dogs_set,
         )
         self.assertEqual(home.dogs.count(), 2)
+        assert 2 == models.Dog.objects.count()  # dogs in dogs_set were created
 
     def test_prepare_fk(self):
         dog = mommy.prepare(models.Dog)


### PR DESCRIPTION
Resolves #377 and a test for it (based on what was described).

This is a fork of @timthelion's solution (https://github.com/berinhard/model_mommy/pull/378). The tests were failing before because many to many relations doesn't have `bulk` as argument. See this [comment from the docs](https://docs.djangoproject.com/en/2.2/ref/models/relations/#django.db.models.fields.related.RelatedManager.set):

> For many-to-many relationships, the bulk keyword argument doesn’t exist.
