### PR TITLE
Get rid of `TestClass` usage (pytest FTW)

### DIFF
--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -37,7 +37,7 @@ GENDER_CHOICES = [
     ('N', 'non-binary'),
 ]
 
-OCCUPATION_CHOCIES = (
+OCCUPATION_CHOICES = (
     ('Service Industry', (
         ('waitress', 'Waitress'),
         ('bartender', 'Bartender'))),
@@ -78,7 +78,7 @@ class Person(models.Model):
     birth_time = models.TimeField()
     appointment = models.DateTimeField()
     blog = models.URLField()
-    occupation = models.CharField(max_length=10, choices=OCCUPATION_CHOCIES)
+    occupation = models.CharField(max_length=10, choices=OCCUPATION_CHOICES)
     uuid = models.UUIDField(primary_key=False)
     name_hash = models.BinaryField(max_length=16)
     wanted_games_qtd = models.BigIntegerField()

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -31,7 +31,11 @@ if MOMMY_GIS:
 else:
     from django.db import models
 
-GENDER_CH = [('M', 'male'), ('F', 'female')]
+GENDER_CHOICES = [
+    ('M', 'male'),
+    ('F', 'female'),
+    ('N', 'non-binary'),
+]
 
 OCCUPATION_CHOCIES = (
     ('Service Industry', (
@@ -62,7 +66,7 @@ class PaymentBill(models.Model):
 
 
 class Person(models.Model):
-    gender = models.CharField(max_length=1, choices=GENDER_CH)
+    gender = models.CharField(max_length=1, choices=GENDER_CHOICES)
     happy = models.BooleanField(default=True)
     unhappy = models.BooleanField(default=False)
     bipolar = models.BooleanField(default=False)

--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -79,6 +79,7 @@ class Person(models.Model):
     name_hash = models.BinaryField(max_length=16)
     wanted_games_qtd = models.BigIntegerField()
     duration_of_sleep = models.DurationField()
+    email = models.EmailField()
 
     try:
         from django.contrib.postgres.fields import ArrayField, HStoreField, JSONField
@@ -178,10 +179,6 @@ class UnsupportedField(models.Field):
 
 class UnsupportedModel(models.Model):
     unsupported_field = UnsupportedField()
-
-
-class DummyEmailModel(models.Model):
-    email_field = models.EmailField()
 
 
 class DummyGenericForeignKeyModel(models.Model):

--- a/tests/test_extending_mommy.py
+++ b/tests/test_extending_mommy.py
@@ -28,13 +28,15 @@ class SadPeopleMommy(mommy.Mommy):
     attr_mapping = {'happy': gen_opposite, 'unhappy': gen_opposite}
 
 
+@pytest.mark.django_db
 class TestSimpleExtendMommy:
-    def test_list_generator_respects_values_from_list(self, db):
+    def test_list_generator_respects_values_from_list(self):
         mom = KidMommy(Person)
         kid = mom.make()
         assert kid.age in KidMommy.age_list
 
 
+@pytest.mark.django_db
 class TestLessSimpleExtendMommy:
     def test_nonexistent_required_field(self):
         gen_opposite.required = ['house']
@@ -42,7 +44,7 @@ class TestLessSimpleExtendMommy:
         with pytest.raises(AttributeError):
             mom.make()
 
-    def test_string_to_generator_required(self, db):
+    def test_string_to_generator_required(self):
         gen_opposite.required = ['default']
         happy_field = Person._meta.get_field('happy')
         unhappy_field = Person._meta.get_field('unhappy')
@@ -52,7 +54,7 @@ class TestLessSimpleExtendMommy:
         assert person.unhappy is not unhappy_field.default
 
     @pytest.mark.parametrize('value', [18, 18.5, [], {}, True])
-    def test_fail_pass_non_string_to_generator_required(self, db, value):
+    def test_fail_pass_non_string_to_generator_required(self, value):
         mom = TeenagerMommy(Person)
 
         gen_age.required = [value]

--- a/tests/test_extending_mommy.py
+++ b/tests/test_extending_mommy.py
@@ -1,97 +1,71 @@
-from django.test import TestCase
+import pytest
 
 from model_mommy import mommy
 from model_mommy.random_gen import gen_from_list
 from model_mommy.exceptions import CustomMommyNotFound, InvalidCustomMommy
 from tests.generic.models import Person
 
-__all__ = ['SimpleExtendMommy', 'LessSimpleExtendMommy', 'CustomizeMommyClassViaSettings']
+
+def gen_opposite(default):
+    return not default
 
 
-class SimpleExtendMommy(TestCase):
+def gen_age():
+    # forever young
+    return 18
 
-    def test_list_generator_respects_values_from_list(self):
-        age_list = range(4, 12)
 
-        class KidMommy(mommy.Mommy):
-            attr_mapping = {'age': gen_from_list(age_list)}
+class KidMommy(mommy.Mommy):
+    age_list = range(4, 12)
+    attr_mapping = {'age': gen_from_list(age_list)}
 
+
+class TeenagerMommy(mommy.Mommy):
+    attr_mapping = {'age': gen_age}
+
+
+class SadPeopleMommy(mommy.Mommy):
+    attr_mapping = {'happy': gen_opposite, 'unhappy': gen_opposite}
+
+
+class TestSimpleExtendMommy:
+    def test_list_generator_respects_values_from_list(self, db):
         mom = KidMommy(Person)
         kid = mom.make()
+        assert kid.age in KidMommy.age_list
 
-        self.assertTrue(kid.age in age_list)
 
-
-class LessSimpleExtendMommy(TestCase):
-
-    def test_unexistent_required_field(self):
-        def gen_opposite(x):
-            return not x
-
+class TestLessSimpleExtendMommy:
+    def test_nonexistent_required_field(self):
         gen_opposite.required = ['house']
-
-        class SadPeopleMommy(mommy.Mommy):
-            attr_mapping = {'happy': gen_opposite}
-
         mom = SadPeopleMommy(Person)
-        self.assertRaises(AttributeError, mom.make)
+        with pytest.raises(AttributeError):
+            mom.make()
 
-    # TODO: put a better name
-    def test_string_to_generator_required(self):
-        def gen_opposite(default):
-            return not default
-
+    def test_string_to_generator_required(self, db):
         gen_opposite.required = ['default']
-
-        class SadPeopleMommy(mommy.Mommy):
-            attr_mapping = {
-                'happy': gen_opposite,
-                'unhappy': gen_opposite,
-            }
-
         happy_field = Person._meta.get_field('happy')
         unhappy_field = Person._meta.get_field('unhappy')
         mom = SadPeopleMommy(Person)
         person = mom.make()
-        self.assertEqual(person.happy, not happy_field.default)
-        self.assertEqual(person.unhappy, not unhappy_field.default)
+        assert person.happy is not happy_field.default
+        assert person.unhappy is not unhappy_field.default
 
-    def test_fail_pass_non_string_to_generator_required(self):
-        def gen_age():
-            return 10
+    @pytest.mark.parametrize('value', [18, 18.5, [], {}, True])
+    def test_fail_pass_non_string_to_generator_required(self, db, value):
+        mom = TeenagerMommy(Person)
 
-        class MyMommy(mommy.Mommy):
-            attr_mapping = {'age': gen_age}
-
-        mom = MyMommy(Person)
-
-        # for int
-        gen_age.required = [10]
-        self.assertRaises(ValueError, mom.make)
-
-        # for float
-        gen_age.required = [10.10]
-        self.assertRaises(ValueError, mom.make)
-
-        # for iterable
-        gen_age.required = [[]]
-        self.assertRaises(ValueError, mom.make)
-
-        # for iterable/dict
-        gen_age.required = [{}]
-        self.assertRaises(ValueError, mom.make)
-
-        # for boolean
-        gen_age.required = [True]
-        self.assertRaises(ValueError, mom.make)
+        gen_age.required = [value]
+        with pytest.raises(ValueError):
+            mom.make()
 
 
-class ClassWithoutMake(object):
+class ClassWithoutMake:
     def prepare(self):
         pass
 
 
-class ClassWithoutPrepare(object):
+class ClassWithoutPrepare:
     def make(self):
         pass
 
@@ -100,7 +74,7 @@ class MommySubclass(mommy.Mommy):
     pass
 
 
-class MommyDuck(object):
+class MommyDuck:
     def __init__(*args, **kwargs):
         pass
 
@@ -111,27 +85,26 @@ class MommyDuck(object):
         pass
 
 
-class CustomizeMommyClassViaSettings(TestCase):
+class TestCustomizeMommyClassViaSettings:
     def class_to_import_string(self, class_to_convert):
         return '%s.%s' % (self.__module__, class_to_convert.__name__)
 
     def test_create_vanilla_mommy_used_by_default(self):
         mommy_instance = mommy.Mommy.create(Person)
-        self.assertIs(mommy_instance.__class__, mommy.Mommy)
+        assert mommy_instance.__class__ == mommy.Mommy
 
-    def test_create_fail_on_custom_mommy_load_error(self):
-        with self.settings(MOMMY_CUSTOM_CLASS='invalid_module.invalid_class'):
-            self.assertRaises(CustomMommyNotFound, mommy.Mommy.create, Person)
+    def test_create_fail_on_custom_mommy_load_error(self, settings):
+        settings.MOMMY_CUSTOM_CLASS = 'invalid_module.invalid_class'
+        with pytest.raises(CustomMommyNotFound):
+            mommy.Mommy.create(Person)
 
-    def test_create_fail_on_missing_required_functions(self):
-        for invalid_mommy_class in [ClassWithoutMake, ClassWithoutPrepare]:
-            with self.settings(
-                MOMMY_CUSTOM_CLASS=self.class_to_import_string(invalid_mommy_class)
-            ):
-                self.assertRaises(InvalidCustomMommy, mommy.Mommy.create, Person)
+    @pytest.mark.parametrize('cls', [ClassWithoutMake, ClassWithoutPrepare])
+    def test_create_fail_on_missing_required_functions(self, settings, cls):
+        settings.MOMMY_CUSTOM_CLASS = self.class_to_import_string(cls)
+        with pytest.raises(InvalidCustomMommy):
+            mommy.Mommy.create(Person)
 
-    def test_create_succeeds_with_valid_custom_mommy(self):
-        for valid_mommy_class in [MommySubclass, MommyDuck]:
-            with self.settings(MOMMY_CUSTOM_CLASS=self.class_to_import_string(valid_mommy_class)):
-                custom_mommy_instance = mommy.Mommy.create(Person)
-                self.assertIs(custom_mommy_instance.__class__, valid_mommy_class)
+    @pytest.mark.parametrize('cls', [MommySubclass, MommyDuck])
+    def test_create_succeeds_with_valid_custom_mommy(self, settings, cls):
+        settings.MOMMY_CUSTOM_CLASS = self.class_to_import_string(cls)
+        assert mommy.Mommy.create(Person).__class__ == cls

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -47,6 +47,15 @@ def person(db):
     return mommy.make('generic.Person')
 
 
+@pytest.fixture()
+def custom_cfg():
+    yield None
+    if hasattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN'):
+        delattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN')
+    mommy.generators.add('tests.generic.fields.CustomFieldWithGenerator', None)
+    mommy.generators.add('django.db.models.fields.CharField', None)
+
+
 class TestFillingFromChoice():
 
     def test_if_gender_is_populated_from_choices(self, person):
@@ -263,14 +272,6 @@ class TestsFillingFileField():
         with pytest.raises(ValueError):
             dummy.file_field.path  # Django raises ValueError if file does not exist
 
-
-@pytest.fixture()
-def custom_cfg():
-    yield None
-    if hasattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN'):
-        delattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN')
-    mommy.generators.add('tests.generic.fields.CustomFieldWithGenerator', None)
-    mommy.generators.add('django.db.models.fields.CharField', None)
 
 class TestFillingCustomFields():
 

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -3,7 +3,6 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from os.path import abspath
 from tempfile import gettempdir
-from unittest import skipUnless
 
 import pytest
 from django.conf import settings
@@ -11,7 +10,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.files import images, File
 from django.db import connection
 from django.db.models import fields, ImageField, FileField
-from django.test import TestCase
 
 from model_mommy import mommy
 from model_mommy.gis import MOMMY_GIS
@@ -49,46 +47,39 @@ def person(db):
     return mommy.make('generic.Person')
 
 
-class FieldFillingTestCase(TestCase):
+class TestFillingFromChoice():
 
-    def setUp(self):
-        self.person = mommy.make(models.Person)
-
-
-class FillingFromChoice(FieldFillingTestCase):
-
-    def test_if_gender_is_populated_from_choices(self):
+    def test_if_gender_is_populated_from_choices(self, person):
         from tests.generic.models import GENDER_CH
-        self.assertTrue(self.person.gender in map(lambda x: x[0], GENDER_CH))
+        person.gender in map(lambda x: x[0], GENDER_CH)
 
-    def test_if_oppucation_populated_from_choices(self):
+    def test_if_oppucation_populated_from_choices(self, person):
         from tests.generic.models import OCCUPATION_CHOCIES
         occupations = [item[0] for list in OCCUPATION_CHOCIES for item in list[1]]
-        self.assertTrue(self.person.occupation in occupations)
+        person.occupation in occupations
 
 
-class StringFieldsFilling(FieldFillingTestCase):
+class TestStringFieldsFilling():
 
-    def test_fill_CharField_with_a_random_str(self):
+    def test_fill_CharField_with_a_random_str(self, person):
         person_name_field = models.Person._meta.get_field('name')
-        self.assertIsInstance(person_name_field, fields.CharField)
+        assert isinstance(person_name_field, fields.CharField)
 
-        self.assertIsInstance(self.person.name, str)
-        self.assertEqual(len(self.person.name), person_name_field.max_length)
+        assert isinstance(person.name, str)
+        assert len(person.name) == person_name_field.max_length
 
-    def test_fill_SlugField_with_a_random_str(self):
+    def test_fill_SlugField_with_a_random_str(self, person):
         person_nickname_field = models.Person._meta.get_field('nickname')
-        self.assertIsInstance(person_nickname_field, fields.SlugField)
+        assert isinstance(person_nickname_field, fields.SlugField)
 
-        self.assertIsInstance(self.person.nickname, str)
-        self.assertEqual(len(self.person.nickname),
-                         person_nickname_field.max_length)
+        assert isinstance(person.nickname, str)
+        assert len(person.nickname) == person_nickname_field.max_length
 
-    def test_fill_TextField_with_a_random_str(self):
+    def test_fill_TextField_with_a_random_str(self, person):
         person_bio_field = models.Person._meta.get_field('bio')
-        self.assertIsInstance(person_bio_field, fields.TextField)
+        assert isinstance(person_bio_field, fields.TextField)
 
-        self.assertIsInstance(self.person.bio, str)
+        assert isinstance(person.bio, str)
 
 
 @pytest.mark.skipif(connection.vendor != 'postgresql', reason='PostgreSQL specific tests')
@@ -110,69 +101,72 @@ class TestCIStringFieldsFilling:
         assert isinstance(person.ci_text, str)
 
 
-class BinaryFieldsFilling(FieldFillingTestCase):
-    def test_fill_BinaryField_with_random_binary(self):
+class TestBinaryFieldsFilling():
+
+    def test_fill_BinaryField_with_random_binary(self, person):
         name_hash_field = models.Person._meta.get_field('name_hash')
-        self.assertIsInstance(name_hash_field, fields.BinaryField)
-        name_hash = self.person.name_hash
-        self.assertIsInstance(name_hash, bytes)
-        self.assertEqual(len(name_hash), name_hash_field.max_length)
+        assert isinstance(name_hash_field, fields.BinaryField)
+        name_hash = person.name_hash
+        assert isinstance(name_hash, bytes)
+        assert len(name_hash) == name_hash_field.max_length
 
 
-class DurationFieldsFilling(FieldFillingTestCase):
-    def test_fill_DurationField_with_random_interval_in_miliseconds(self):
+class TestsDurationFieldsFilling():
+
+    def test_fill_DurationField_with_random_interval_in_miliseconds(self, person):
         duration_of_sleep_field = models.Person._meta.get_field('duration_of_sleep')
-        self.assertIsInstance(duration_of_sleep_field, fields.DurationField)
-        duration_of_sleep = self.person.duration_of_sleep
-        self.assertIsInstance(duration_of_sleep, timedelta)
+        assert isinstance(duration_of_sleep_field, fields.DurationField)
+        duration_of_sleep = person.duration_of_sleep
+        assert isinstance(duration_of_sleep, timedelta)
 
 
-class BooleanFieldsFilling(FieldFillingTestCase):
-    def test_fill_BooleanField_with_boolean(self):
+class TestBooleanFieldsFilling():
+
+    def test_fill_BooleanField_with_boolean(self, person):
         happy_field = models.Person._meta.get_field('happy')
-        self.assertIsInstance(happy_field, fields.BooleanField)
+        assert isinstance(happy_field, fields.BooleanField)
 
-        self.assertIsInstance(self.person.happy, bool)
-        self.assertTrue(self.person.happy)
+        assert isinstance(person.happy, bool)
+        assert person.happy is True
 
-    def test_fill_BooleanField_with_false_if_default_is_false(self):
+    def test_fill_BooleanField_with_false_if_default_is_false(self, person):
         unhappy_field = models.Person._meta.get_field('unhappy')
-        self.assertIsInstance(unhappy_field, fields.BooleanField)
+        assert isinstance(unhappy_field, fields.BooleanField)
 
-        self.assertIsInstance(self.person.unhappy, bool)
-        self.assertFalse(self.person.unhappy)
+        assert isinstance(person.unhappy, bool)
+        assert person.unhappy is False
 
 
-class DateFieldsFilling(FieldFillingTestCase):
+class TestDateFieldsFilling():
 
-    def test_fill_DateField_with_a_date(self):
+    def test_fill_DateField_with_a_date(self, person):
         birthday_field = models.Person._meta.get_field('birthday')
-        self.assertIsInstance(birthday_field, fields.DateField)
-        self.assertIsInstance(self.person.birthday, date)
+        assert isinstance(birthday_field, fields.DateField)
+        assert isinstance(person.birthday, date)
 
 
-class DateTimeFieldsFilling(FieldFillingTestCase):
+class TestDateTimeFieldsFilling():
 
-    def test_fill_DateTimeField_with_a_datetime(self):
+    def test_fill_DateTimeField_with_a_datetime(self, person):
         appointment_field = models.Person._meta.get_field('appointment')
-        self.assertIsInstance(appointment_field, fields.DateTimeField)
-        self.assertIsInstance(self.person.appointment, datetime)
+        assert isinstance(appointment_field, fields.DateTimeField)
+        assert isinstance(person.appointment, datetime)
 
 
-class TimeFieldsFilling(FieldFillingTestCase):
+class TestTimeFieldsFilling():
 
-    def test_fill_TimeField_with_a_time(self):
+    def test_fill_TimeField_with_a_time(self, person):
         birth_time_field = models.Person._meta.get_field('birth_time')
-        self.assertIsInstance(birth_time_field, fields.TimeField)
-        self.assertIsInstance(self.person.birth_time, time)
+        assert isinstance(birth_time_field, fields.TimeField)
+        assert isinstance(person.birth_time, time)
 
 
-class UUIDFieldsFilling(FieldFillingTestCase):
-    def test_fill_UUIDField_with_uuid_object(self):
+class TestUUIDFieldsFilling():
+
+    def test_fill_UUIDField_with_uuid_object(self, person):
         uuid_field = models.Person._meta.get_field('uuid')
-        self.assertIsInstance(uuid_field, fields.UUIDField)
-
-        self.assertIsInstance(self.person.uuid, uuid.UUID)
+        assert isinstance(uuid_field, fields.UUIDField)
+        assert isinstance(person.uuid, uuid.UUID)
 
 
 @pytest.mark.skipif(connection.vendor != 'postgresql', reason='PostgreSQL specific tests')
@@ -187,175 +181,164 @@ class TestPostgreSQLFieldsFilling:
         assert person.hstore_data == {}
 
 
-class FillingIntFields(TestCase):
+class TestFillingIntFields():
 
-    def setUp(self):
-        self.dummy_int_model = mommy.make(models.DummyIntModel)
-
-    def test_fill_IntegerField_with_a_random_number(self):
+    def test_fill_IntegerField_with_a_random_number(self, db):
+        dummy_int_model = mommy.make(models.DummyIntModel)
         int_field = models.DummyIntModel._meta.get_field('int_field')
-        self.assertIsInstance(int_field, fields.IntegerField)
-        self.assertIsInstance(self.dummy_int_model.int_field, int)
+        assert isinstance(int_field, fields.IntegerField)
+        assert isinstance(dummy_int_model.int_field, int)
 
-    def test_fill_BigIntegerField_with_a_random_number(self):
+    def test_fill_BigIntegerField_with_a_random_number(self, db):
+        dummy_int_model = mommy.make(models.DummyIntModel)
         big_int_field = models.DummyIntModel._meta.get_field('big_int_field')
-        self.assertIsInstance(big_int_field, fields.BigIntegerField)
-        self.assertIsInstance(self.dummy_int_model.big_int_field, int)
+        assert isinstance(big_int_field, fields.BigIntegerField)
+        assert isinstance(dummy_int_model.big_int_field, int)
 
-    def test_fill_SmallIntegerField_with_a_random_number(self):
+    def test_fill_SmallIntegerField_with_a_random_number(self, db):
+        dummy_int_model = mommy.make(models.DummyIntModel)
         small_int_field = models.DummyIntModel._meta.get_field('small_int_field')
-        self.assertIsInstance(small_int_field, fields.SmallIntegerField)
-        self.assertIsInstance(self.dummy_int_model.small_int_field, int)
+        assert isinstance(small_int_field, fields.SmallIntegerField)
+        assert isinstance(dummy_int_model.small_int_field, int)
 
 
-class FillingPositiveIntFields(TestCase):
+class TestFillingPositiveIntFields():
 
-    def setUp(self):
-        self.dummy_positive_int_model = mommy.make(models.DummyPositiveIntModel)
-
-    def test_fill_PositiveSmallIntegerField_with_a_random_number(self):
+    def test_fill_PositiveSmallIntegerField_with_a_random_number(self, db):
+        dummy_positive_int_model = mommy.make(models.DummyPositiveIntModel)
         field = models.DummyPositiveIntModel._meta.get_field('positive_small_int_field')
         positive_small_int_field = field
-        self.assertIsInstance(positive_small_int_field, fields.PositiveSmallIntegerField)
-        self.assertIsInstance(self.dummy_positive_int_model.positive_small_int_field, int)
-        self.assertTrue(self.dummy_positive_int_model.positive_small_int_field > 0)
+        assert isinstance(positive_small_int_field, fields.PositiveSmallIntegerField)
+        assert isinstance(dummy_positive_int_model.positive_small_int_field, int)
+        assert dummy_positive_int_model.positive_small_int_field > 0
 
-    def test_fill_PositiveIntegerField_with_a_random_number(self):
+    def test_fill_PositiveIntegerField_with_a_random_number(self, db):
+        dummy_positive_int_model = mommy.make(models.DummyPositiveIntModel)
         positive_int_field = models.DummyPositiveIntModel._meta.get_field('positive_int_field')
-        self.assertIsInstance(positive_int_field, fields.PositiveIntegerField)
-        self.assertIsInstance(self.dummy_positive_int_model.positive_int_field, int)
-        self.assertTrue(self.dummy_positive_int_model.positive_int_field > 0)
+        assert isinstance(positive_int_field, fields.PositiveIntegerField)
+        assert isinstance(dummy_positive_int_model.positive_int_field, int)
+        assert dummy_positive_int_model.positive_int_field > 0
 
 
-class FillingOthersNumericFields(TestCase):
-    def test_filling_FloatField_with_a_random_float(self):
+class TestFillingOthersNumericFields():
+
+    def test_filling_FloatField_with_a_random_float(self, db):
         self.dummy_numbers_model = mommy.make(models.DummyNumbersModel)
         float_field = models.DummyNumbersModel._meta.get_field('float_field')
-        self.assertIsInstance(float_field, fields.FloatField)
-        self.assertIsInstance(self.dummy_numbers_model.float_field, float)
+        assert isinstance(float_field, fields.FloatField)
+        assert isinstance(self.dummy_numbers_model.float_field, float)
 
-    def test_filling_DecimalField_with_random_decimal(self):
+    def test_filling_DecimalField_with_random_decimal(self, db):
         self.dummy_decimal_model = mommy.make(models.DummyDecimalModel)
         decimal_field = models.DummyDecimalModel._meta.get_field('decimal_field')
-        self.assertIsInstance(decimal_field, fields.DecimalField)
-        self.assertIsInstance(self.dummy_decimal_model.decimal_field, Decimal)
+        assert isinstance(decimal_field, fields.DecimalField)
+        assert isinstance(self.dummy_decimal_model.decimal_field, Decimal)
 
 
-class URLFieldsFilling(FieldFillingTestCase):
+class TestURLFieldsFilling():
 
-    def test_fill_URLField_with_valid_url(self):
+    def test_fill_URLField_with_valid_url(self, person):
         blog_field = models.Person._meta.get_field('blog')
-        self.assertIsInstance(blog_field, fields.URLField)
-        self.assertIsInstance(self.person.blog, str)
+        assert isinstance(blog_field, fields.URLField)
+        assert isinstance(person.blog, str)
 
 
-class FillingEmailField(TestCase):
+class TestFillingEmailField():
 
-    def test_filling_EmailField(self):
-        obj = mommy.make(models.DummyEmailModel)
-        field = models.DummyEmailModel._meta.get_field('email_field')
-        self.assertIsInstance(field, fields.EmailField)
-        self.assertIsInstance(obj.email_field, str)
+    def test_filling_EmailField(self, person):
+        field = models.Person._meta.get_field('email')
+        assert isinstance(field, fields.EmailField)
+        assert isinstance(person.email, str)
 
 
-class FillingIPAddressField(TestCase):
+class TestFillingIPAddressField():
 
-    def test_filling_IPAddressField(self):
+    def test_filling_IPAddressField(self, db):
         obj = mommy.make(models.DummyGenericIPAddressFieldModel)
         field = models.DummyGenericIPAddressFieldModel._meta.get_field('ipv4_field')
-        self.assertIsInstance(field, fields.GenericIPAddressField)
-        self.assertIsInstance(obj.ipv4_field, str)
+        assert isinstance(field, fields.GenericIPAddressField)
+        assert isinstance(obj.ipv4_field, str)
 
         validate_ipv4_address(obj.ipv4_field)
 
         if hasattr(obj, 'ipv6_field'):
-            self.assertIsInstance(obj.ipv6_field, str)
-            self.assertIsInstance(obj.ipv46_field, str)
+            assert isinstance(obj.ipv6_field, str)
+            assert isinstance(obj.ipv46_field, str)
 
             validate_ipv6_address(obj.ipv6_field)
             validate_ipv46_address(obj.ipv46_field)
 
 
-class FillingGenericForeignKeyField(TestCase):
+class TestFillingGenericForeignKeyField():
 
-    def test_filling_content_type_field(self):
+    def test_filling_content_type_field(self, db):
         dummy = mommy.make(models.DummyGenericForeignKeyModel)
-        self.assertIsInstance(dummy.content_type, ContentType)
-        self.assertIsNotNone(dummy.content_type.model_class())
+        assert isinstance(dummy.content_type, ContentType)
+        assert dummy.content_type.model_class() is not None
 
 
-class FillingFileField(TestCase):
+class TestsFillingFileField():
 
-    def setUp(self):
-        path = mommy.mock_file_txt
-        self.fixture_txt_file = File(open(path))
-
-    def tearDown(self):
-        self.dummy.file_field.delete()
-
-    def test_filling_file_field(self):
-        self.dummy = mommy.make(models.DummyFileFieldModel, _create_files=True)
+    def test_filling_file_field(self, db):
+        dummy = mommy.make(models.DummyFileFieldModel, _create_files=True)
         field = models.DummyFileFieldModel._meta.get_field('file_field')
-        self.assertIsInstance(field, FileField)
+        assert isinstance(field, FileField)
         import time
         path = "%s/%s/mock_file.txt" % (gettempdir(), time.strftime('%Y/%m/%d'))
 
-        self.assertEqual(abspath(self.dummy.file_field.path), abspath(path))
+        assert abspath(path) == abspath(dummy.file_field.path)
+        dummy.file_field.delete()
 
-    def test_does_not_create_file_if_not_flagged(self):
-        self.dummy = mommy.make(models.DummyFileFieldModel)
-        with self.assertRaises(ValueError):
-            self.dummy.file_field.path  # Django raises ValueError if file does not exist
+    def test_does_not_create_file_if_not_flagged(self, db):
+        dummy = mommy.make(models.DummyFileFieldModel)
+        with pytest.raises(ValueError):
+            dummy.file_field.path  # Django raises ValueError if file does not exist
 
 
-@skipUnless(models.has_pil, "PIL is required to test ImageField")
-class FillingImageFileField(TestCase):
+@pytest.mark.skipif(not models.has_pil, reason="PIL is required to test ImageField")
+class TestFillingImageFileField():
 
-    def setUp(self):
-        path = mommy.mock_file_jpeg
-        self.fixture_img_file = images.ImageFile(open(path))
-
-    def tearDown(self):
-        self.dummy.image_field.delete()
-
-    def test_filling_image_file_field(self):
-        self.dummy = mommy.make(models.DummyImageFieldModel, _create_files=True)
+    def test_filling_image_file_field(self, db):
+        dummy = mommy.make(models.DummyImageFieldModel, _create_files=True)
         field = models.DummyImageFieldModel._meta.get_field('image_field')
-        self.assertIsInstance(field, ImageField)
+        assert isinstance(field, ImageField)
         import time
         path = "%s/%s/mock-img.jpeg" % (gettempdir(), time.strftime('%Y/%m/%d'))
 
         # These require the file to exist in earlier versions of Django
-        self.assertEqual(abspath(self.dummy.image_field.path), abspath(path))
-        self.assertTrue(self.dummy.image_field.width)
-        self.assertTrue(self.dummy.image_field.height)
+        assert abspath(path) == abspath(dummy.image_field.path)
+        assert dummy.image_field.width
+        assert dummy.image_field.height
+        dummy.image_field.delete()
 
-    def test_does_not_create_file_if_not_flagged(self):
-        self.dummy = mommy.make(models.DummyImageFieldModel)
-        with self.assertRaises(ValueError):
-            self.dummy.image_field.path  # Django raises ValueError if file does not exist
+    def test_does_not_create_file_if_not_flagged(self, db):
+        dummy = mommy.make(models.DummyImageFieldModel)
+        with pytest.raises(ValueError):
+            dummy.image_field.path  # Django raises ValueError if file does not exist
 
+@pytest.fixture()
+def custom_cfg():
+    yield None
+    if hasattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN'):
+        delattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN')
+    mommy.generators.add('tests.generic.fields.CustomFieldWithGenerator', None)
+    mommy.generators.add('django.db.models.fields.CharField', None)
 
-class FillingCustomFields(TestCase):
+class TestFillingCustomFields():
 
-    def tearDown(self):
-        if hasattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN'):
-            delattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN')
-        mommy.generators.add('tests.generic.fields.CustomFieldWithGenerator', None)
-        mommy.generators.add('django.db.models.fields.CharField', None)
-
-    def test_raises_unsupported_field_for_custom_field(self):
+    def test_raises_unsupported_field_for_custom_field(self, db, custom_cfg):
         """Should raise an exception if a generator is not provided for a custom field"""
-        self.assertRaises(TypeError, mommy.make, models.CustomFieldWithoutGeneratorModel)
+        with pytest.raises(TypeError):
+            mommy.make(models.CustomFieldWithoutGeneratorModel)
 
-    def test_uses_generator_defined_on_settings_for_custom_field(self):
+    def test_uses_generator_defined_on_settings_for_custom_field(self, db, custom_cfg):
         """Should use the function defined in settings as a generator"""
         generator_dict = {'tests.generic.fields.CustomFieldWithGenerator': generators.gen_value_string}
         setattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN', generator_dict)
         obj = mommy.make(models.CustomFieldWithGeneratorModel)
-        self.assertEqual("value", obj.custom_value)
+        assert "value" == obj.custom_value
 
-    def test_uses_generator_defined_as_string_on_settings_for_custom_field(self):
+    def test_uses_generator_defined_as_string_on_settings_for_custom_field(self, db, custom_cfg):
         """Should import and use the function present in the import path defined in settings"""
         generator_dict = {
             'tests.generic.fields.CustomFieldWithGenerator':
@@ -363,33 +346,33 @@ class FillingCustomFields(TestCase):
         }
         setattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN', generator_dict)
         obj = mommy.make(models.CustomFieldWithGeneratorModel)
-        self.assertEqual("value", obj.custom_value)
+        assert "value" == obj.custom_value
 
-    def test_uses_generator_defined_on_settings_for_custom_foreignkey(self):
+    def test_uses_generator_defined_on_settings_for_custom_foreignkey(self, db, custom_cfg):
         """Should use the function defined in the import path for a foreign key field"""
         generator_dict = {
             'tests.generic.fields.CustomForeignKey': 'model_mommy.random_gen.gen_related'
         }
         setattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN', generator_dict)
         obj = mommy.make(models.CustomForeignKeyWithGeneratorModel, custom_fk__email="a@b.com")
-        self.assertEqual('a@b.com', obj.custom_fk.email)
+        assert 'a@b.com' == obj.custom_fk.email
 
-    def test_uses_generator_defined_as_string_for_custom_field(self):
+    def test_uses_generator_defined_as_string_for_custom_field(self, db, custom_cfg):
         """Should import and use the generator function used in the add method"""
         mommy.generators.add(
             'tests.generic.fields.CustomFieldWithGenerator',
             'tests.generic.generators.gen_value_string'
         )
         obj = mommy.make(models.CustomFieldWithGeneratorModel)
-        self.assertEqual("value", obj.custom_value)
+        assert "value" == obj.custom_value
 
-    def test_uses_generator_function_for_custom_foreignkey(self):
+    def test_uses_generator_function_for_custom_foreignkey(self, db, custom_cfg):
         """Should use the generator function passed as a value for the add method"""
         mommy.generators.add('tests.generic.fields.CustomForeignKey', gen_related)
         obj = mommy.make(models.CustomForeignKeyWithGeneratorModel, custom_fk__email="a@b.com")
-        self.assertEqual('a@b.com', obj.custom_fk.email)
+        assert 'a@b.com' == obj.custom_fk.email
 
-    def test_can_override_django_default_field_functions_generator(self):
+    def test_can_override_django_default_field_functions_generator(self, db, custom_cfg):
         def gen_char():
             return 'Some value'
 
@@ -397,44 +380,45 @@ class FillingCustomFields(TestCase):
 
         person = mommy.make(models.Person)
 
-        self.assertEqual('Some value', person.name)
+        assert 'Some value' == person.name
 
 
-class FillingAutoFields(TestCase):
+class TestFillingAutoFields():
 
-    def test_filling_AutoField(self):
+    def test_filling_AutoField(self, db):
         obj = mommy.make(models.DummyEmptyModel)
         field = models.DummyEmptyModel._meta.get_field('id')
-        self.assertIsInstance(field, fields.AutoField)
-        self.assertIsInstance(obj.id, int)
+        assert isinstance(field, fields.AutoField)
+        assert isinstance(obj.id, int)
 
 
-@skipUnless(MOMMY_GIS, "GIS support required for GIS fields")
-class GisFieldsFilling(FieldFillingTestCase):
+@pytest.mark.skipif(not MOMMY_GIS, reason="GIS support required for GIS fields")
+class TestGisFieldsFilling():
 
     def assertGeomValid(self, geom):
-        self.assertTrue(geom.valid, geom.valid_reason)
+        assert geom.valid is True, geom.valid_reason
 
-    def test_fill_PointField_valid(self):
-        self.assertGeomValid(self.person.point)
+    def test_fill_PointField_valid(self, person):
+        print(MOMMY_GIS)
+        self.assertGeomValid(person.point)
 
-    def test_fill_LineStringField_valid(self):
-        self.assertGeomValid(self.person.line_string)
+    def test_fill_LineStringField_valid(self, person):
+        self.assertGeomValid(person.line_string)
 
-    def test_fill_PolygonField_valid(self):
-        self.assertGeomValid(self.person.polygon)
+    def test_fill_PolygonField_valid(self, person):
+        self.assertGeomValid(person.polygon)
 
-    def test_fill_MultiPointField_valid(self):
-        self.assertGeomValid(self.person.multi_point)
+    def test_fill_MultiPointField_valid(self, person):
+        self.assertGeomValid(person.multi_point)
 
-    def test_fill_MultiLineStringField_valid(self):
-        self.assertGeomValid(self.person.multi_line_string)
+    def test_fill_MultiLineStringField_valid(self, person):
+        self.assertGeomValid(person.multi_line_string)
 
-    def test_fill_MultiPolygonField_valid(self):
-        self.assertGeomValid(self.person.multi_polygon)
+    def test_fill_MultiPolygonField_valid(self, person):
+        self.assertGeomValid(person.multi_polygon)
 
-    def test_fill_GeometryField_valid(self):
-        self.assertGeomValid(self.person.geom)
+    def test_fill_GeometryField_valid(self, person):
+        self.assertGeomValid(person.geom)
 
-    def test_fill_GeometryCollectionField_valid(self):
-        self.assertGeomValid(self.person.geom_collection)
+    def test_fill_GeometryCollectionField_valid(self, person):
+        self.assertGeomValid(person.geom_collection)

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -99,7 +99,7 @@ class TestsDurationFieldsFilling():
         duration_of_sleep_field = models.Person._meta.get_field('duration_of_sleep')
         assert isinstance(duration_of_sleep_field, fields.DurationField)
         duration_of_sleep = person.duration_of_sleep
-        assert isinstance(duration_of_sleep, timedelta)
+        assert isinstance(person.duration_of_sleep, timedelta)
 
 
 class TestBooleanFieldsFilling():

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -51,8 +51,8 @@ def custom_cfg():
 class TestFillingFromChoice():
 
     def test_if_gender_is_populated_from_choices(self, person):
-        from tests.generic.models import GENDER_CH
-        person.gender in map(lambda x: x[0], GENDER_CH)
+        from tests.generic.models import GENDER_CHOICES
+        person.gender in map(lambda x: x[0], GENDER_CHOICES)
 
     def test_if_oppucation_populated_from_choices(self, person):
         from tests.generic.models import OCCUPATION_CHOCIES

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -55,7 +55,7 @@ class TestFillingFromChoice():
         person.gender in map(lambda x: x[0], GENDER_CHOICES)
 
     def test_if_occupation_populated_from_choices(self, person):
-        from tests.generic.models import OCCUPATION_CHOCIES
+        from tests.generic.models import OCCUPATION_CHOICES
         occupations = [item[0] for list in OCCUPATION_CHOCIES for item in list[1]]
         person.occupation in occupations
 

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -34,14 +34,6 @@ from django.core.validators import (
 )
 
 
-def assert_not_raise(method, parameters, exception):
-    try:
-        method(*parameters)
-    except exception:
-        msg = "Exception %s not expected to be raised" % exception.__name__
-        raise AssertionError(msg)
-
-
 @pytest.fixture
 def person(db):
     return mommy.make('generic.Person')

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -54,7 +54,7 @@ class TestFillingFromChoice():
         from tests.generic.models import GENDER_CHOICES
         person.gender in map(lambda x: x[0], GENDER_CHOICES)
 
-    def test_if_oppucation_populated_from_choices(self, person):
+    def test_if_occupation_populated_from_choices(self, person):
         from tests.generic.models import OCCUPATION_CHOCIES
         occupations = [item[0] for list in OCCUPATION_CHOCIES for item in list[1]]
         person.occupation in occupations

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -56,7 +56,7 @@ class TestFillingFromChoice():
 
     def test_if_occupation_populated_from_choices(self, person):
         from tests.generic.models import OCCUPATION_CHOICES
-        occupations = [item[0] for list in OCCUPATION_CHOCIES for item in list[1]]
+        occupations = [item[0] for list in OCCUPATION_CHOICES for item in list[1]]
         person.occupation in occupations
 
 

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -151,30 +151,32 @@ class TestUUIDFieldsFilling():
         assert isinstance(person.uuid, uuid.UUID)
 
 
+@pytest.mark.django_db
 class TestFillingIntFields():
 
-    def test_fill_IntegerField_with_a_random_number(self, db):
+    def test_fill_IntegerField_with_a_random_number(self):
         dummy_int_model = mommy.make(models.DummyIntModel)
         int_field = models.DummyIntModel._meta.get_field('int_field')
         assert isinstance(int_field, fields.IntegerField)
         assert isinstance(dummy_int_model.int_field, int)
 
-    def test_fill_BigIntegerField_with_a_random_number(self, db):
+    def test_fill_BigIntegerField_with_a_random_number(self):
         dummy_int_model = mommy.make(models.DummyIntModel)
         big_int_field = models.DummyIntModel._meta.get_field('big_int_field')
         assert isinstance(big_int_field, fields.BigIntegerField)
         assert isinstance(dummy_int_model.big_int_field, int)
 
-    def test_fill_SmallIntegerField_with_a_random_number(self, db):
+    def test_fill_SmallIntegerField_with_a_random_number(self):
         dummy_int_model = mommy.make(models.DummyIntModel)
         small_int_field = models.DummyIntModel._meta.get_field('small_int_field')
         assert isinstance(small_int_field, fields.SmallIntegerField)
         assert isinstance(dummy_int_model.small_int_field, int)
 
 
+@pytest.mark.django_db
 class TestFillingPositiveIntFields():
 
-    def test_fill_PositiveSmallIntegerField_with_a_random_number(self, db):
+    def test_fill_PositiveSmallIntegerField_with_a_random_number(self):
         dummy_positive_int_model = mommy.make(models.DummyPositiveIntModel)
         field = models.DummyPositiveIntModel._meta.get_field('positive_small_int_field')
         positive_small_int_field = field
@@ -182,7 +184,7 @@ class TestFillingPositiveIntFields():
         assert isinstance(dummy_positive_int_model.positive_small_int_field, int)
         assert dummy_positive_int_model.positive_small_int_field > 0
 
-    def test_fill_PositiveIntegerField_with_a_random_number(self, db):
+    def test_fill_PositiveIntegerField_with_a_random_number(self):
         dummy_positive_int_model = mommy.make(models.DummyPositiveIntModel)
         positive_int_field = models.DummyPositiveIntModel._meta.get_field('positive_int_field')
         assert isinstance(positive_int_field, fields.PositiveIntegerField)
@@ -190,15 +192,16 @@ class TestFillingPositiveIntFields():
         assert dummy_positive_int_model.positive_int_field > 0
 
 
+@pytest.mark.django_db
 class TestFillingOthersNumericFields():
 
-    def test_filling_FloatField_with_a_random_float(self, db):
+    def test_filling_FloatField_with_a_random_float(self):
         self.dummy_numbers_model = mommy.make(models.DummyNumbersModel)
         float_field = models.DummyNumbersModel._meta.get_field('float_field')
         assert isinstance(float_field, fields.FloatField)
         assert isinstance(self.dummy_numbers_model.float_field, float)
 
-    def test_filling_DecimalField_with_random_decimal(self, db):
+    def test_filling_DecimalField_with_random_decimal(self):
         self.dummy_decimal_model = mommy.make(models.DummyDecimalModel)
         decimal_field = models.DummyDecimalModel._meta.get_field('decimal_field')
         assert isinstance(decimal_field, fields.DecimalField)
@@ -221,9 +224,10 @@ class TestFillingEmailField():
         assert isinstance(person.email, str)
 
 
+@pytest.mark.django_db
 class TestFillingIPAddressField():
 
-    def test_filling_IPAddressField(self, db):
+    def test_filling_IPAddressField(self):
         obj = mommy.make(models.DummyGenericIPAddressFieldModel)
         field = models.DummyGenericIPAddressFieldModel._meta.get_field('ipv4_field')
         assert isinstance(field, fields.GenericIPAddressField)
@@ -239,17 +243,19 @@ class TestFillingIPAddressField():
             validate_ipv46_address(obj.ipv46_field)
 
 
+@pytest.mark.django_db
 class TestFillingGenericForeignKeyField():
 
-    def test_filling_content_type_field(self, db):
+    def test_filling_content_type_field(self):
         dummy = mommy.make(models.DummyGenericForeignKeyModel)
         assert isinstance(dummy.content_type, ContentType)
         assert dummy.content_type.model_class() is not None
 
 
+@pytest.mark.django_db
 class TestsFillingFileField():
 
-    def test_filling_file_field(self, db):
+    def test_filling_file_field(self):
         dummy = mommy.make(models.DummyFileFieldModel, _create_files=True)
         field = models.DummyFileFieldModel._meta.get_field('file_field')
         assert isinstance(field, FileField)
@@ -259,27 +265,28 @@ class TestsFillingFileField():
         assert abspath(path) == abspath(dummy.file_field.path)
         dummy.file_field.delete()
 
-    def test_does_not_create_file_if_not_flagged(self, db):
+    def test_does_not_create_file_if_not_flagged(self):
         dummy = mommy.make(models.DummyFileFieldModel)
         with pytest.raises(ValueError):
             dummy.file_field.path  # Django raises ValueError if file does not exist
 
 
+@pytest.mark.django_db
 class TestFillingCustomFields():
 
-    def test_raises_unsupported_field_for_custom_field(self, db, custom_cfg):
+    def test_raises_unsupported_field_for_custom_field(self, custom_cfg):
         """Should raise an exception if a generator is not provided for a custom field"""
         with pytest.raises(TypeError):
             mommy.make(models.CustomFieldWithoutGeneratorModel)
 
-    def test_uses_generator_defined_on_settings_for_custom_field(self, db, custom_cfg):
+    def test_uses_generator_defined_on_settings_for_custom_field(self, custom_cfg):
         """Should use the function defined in settings as a generator"""
         generator_dict = {'tests.generic.fields.CustomFieldWithGenerator': generators.gen_value_string}
         setattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN', generator_dict)
         obj = mommy.make(models.CustomFieldWithGeneratorModel)
         assert "value" == obj.custom_value
 
-    def test_uses_generator_defined_as_string_on_settings_for_custom_field(self, db, custom_cfg):
+    def test_uses_generator_defined_as_string_on_settings_for_custom_field(self, custom_cfg):
         """Should import and use the function present in the import path defined in settings"""
         generator_dict = {
             'tests.generic.fields.CustomFieldWithGenerator':
@@ -289,7 +296,7 @@ class TestFillingCustomFields():
         obj = mommy.make(models.CustomFieldWithGeneratorModel)
         assert "value" == obj.custom_value
 
-    def test_uses_generator_defined_on_settings_for_custom_foreignkey(self, db, custom_cfg):
+    def test_uses_generator_defined_on_settings_for_custom_foreignkey(self, custom_cfg):
         """Should use the function defined in the import path for a foreign key field"""
         generator_dict = {
             'tests.generic.fields.CustomForeignKey': 'model_mommy.random_gen.gen_related'
@@ -298,7 +305,7 @@ class TestFillingCustomFields():
         obj = mommy.make(models.CustomForeignKeyWithGeneratorModel, custom_fk__email="a@b.com")
         assert 'a@b.com' == obj.custom_fk.email
 
-    def test_uses_generator_defined_as_string_for_custom_field(self, db, custom_cfg):
+    def test_uses_generator_defined_as_string_for_custom_field(self, custom_cfg):
         """Should import and use the generator function used in the add method"""
         mommy.generators.add(
             'tests.generic.fields.CustomFieldWithGenerator',
@@ -307,13 +314,13 @@ class TestFillingCustomFields():
         obj = mommy.make(models.CustomFieldWithGeneratorModel)
         assert "value" == obj.custom_value
 
-    def test_uses_generator_function_for_custom_foreignkey(self, db, custom_cfg):
+    def test_uses_generator_function_for_custom_foreignkey(self, custom_cfg):
         """Should use the generator function passed as a value for the add method"""
         mommy.generators.add('tests.generic.fields.CustomForeignKey', gen_related)
         obj = mommy.make(models.CustomForeignKeyWithGeneratorModel, custom_fk__email="a@b.com")
         assert 'a@b.com' == obj.custom_fk.email
 
-    def test_can_override_django_default_field_functions_generator(self, db, custom_cfg):
+    def test_can_override_django_default_field_functions_generator(self, custom_cfg):
         def gen_char():
             return 'Some value'
 
@@ -324,19 +331,21 @@ class TestFillingCustomFields():
         assert 'Some value' == person.name
 
 
+@pytest.mark.django_db
 class TestFillingAutoFields():
 
-    def test_filling_AutoField(self, db):
+    def test_filling_AutoField(self):
         obj = mommy.make(models.DummyEmptyModel)
         field = models.DummyEmptyModel._meta.get_field('id')
         assert isinstance(field, fields.AutoField)
         assert isinstance(obj.id, int)
 
 
+@pytest.mark.django_db
 @pytest.mark.skipif(not models.has_pil, reason="PIL is required to test ImageField")
 class TestFillingImageFileField():
 
-    def test_filling_image_file_field(self, db):
+    def test_filling_image_file_field(self):
         dummy = mommy.make(models.DummyImageFieldModel, _create_files=True)
         field = models.DummyImageFieldModel._meta.get_field('image_field')
         assert isinstance(field, ImageField)
@@ -349,7 +358,7 @@ class TestFillingImageFileField():
         assert dummy.image_field.height
         dummy.image_field.delete()
 
-    def test_does_not_create_file_if_not_flagged(self, db):
+    def test_does_not_create_file_if_not_flagged(self):
         dummy = mommy.make(models.DummyImageFieldModel)
         with pytest.raises(ValueError):
             dummy.image_field.path  # Django raises ValueError if file does not exist

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -82,25 +82,6 @@ class TestStringFieldsFilling():
         assert isinstance(person.bio, str)
 
 
-@pytest.mark.skipif(connection.vendor != 'postgresql', reason='PostgreSQL specific tests')
-class TestCIStringFieldsFilling:
-    def test_fill_cicharfield_with_a_random_str(self, person):
-        ci_char_field = models.Person._meta.get_field('ci_char')
-        assert isinstance(ci_char_field, CICharField)
-        assert isinstance(person.ci_char, str)
-        assert len(person.ci_char) == ci_char_field.max_length
-
-    def test_filling_ciemailfield(self, person):
-        ci_email_field = models.Person._meta.get_field('ci_email')
-        assert isinstance(ci_email_field, CIEmailField)
-        assert isinstance(person.ci_email, str)
-
-    def test_filling_citextfield(self, person):
-        ci_text_field = models.Person._meta.get_field('ci_text')
-        assert isinstance(ci_text_field, CITextField)
-        assert isinstance(person.ci_text, str)
-
-
 class TestBinaryFieldsFilling():
 
     def test_fill_BinaryField_with_random_binary(self, person):
@@ -167,18 +148,6 @@ class TestUUIDFieldsFilling():
         uuid_field = models.Person._meta.get_field('uuid')
         assert isinstance(uuid_field, fields.UUIDField)
         assert isinstance(person.uuid, uuid.UUID)
-
-
-@pytest.mark.skipif(connection.vendor != 'postgresql', reason='PostgreSQL specific tests')
-class TestPostgreSQLFieldsFilling:
-    def test_fill_arrayfield_with_empty_array(self, person):
-        assert person.acquaintances == []
-
-    def test_fill_jsonfield_with_empty_dict(self, person):
-        assert person.data == {}
-
-    def test_fill_hstorefield_with_empty_dict(self, person):
-        assert person.hstore_data == {}
 
 
 class TestFillingIntFields():
@@ -295,27 +264,6 @@ class TestsFillingFileField():
             dummy.file_field.path  # Django raises ValueError if file does not exist
 
 
-@pytest.mark.skipif(not models.has_pil, reason="PIL is required to test ImageField")
-class TestFillingImageFileField():
-
-    def test_filling_image_file_field(self, db):
-        dummy = mommy.make(models.DummyImageFieldModel, _create_files=True)
-        field = models.DummyImageFieldModel._meta.get_field('image_field')
-        assert isinstance(field, ImageField)
-        import time
-        path = "%s/%s/mock-img.jpeg" % (gettempdir(), time.strftime('%Y/%m/%d'))
-
-        # These require the file to exist in earlier versions of Django
-        assert abspath(path) == abspath(dummy.image_field.path)
-        assert dummy.image_field.width
-        assert dummy.image_field.height
-        dummy.image_field.delete()
-
-    def test_does_not_create_file_if_not_flagged(self, db):
-        dummy = mommy.make(models.DummyImageFieldModel)
-        with pytest.raises(ValueError):
-            dummy.image_field.path  # Django raises ValueError if file does not exist
-
 @pytest.fixture()
 def custom_cfg():
     yield None
@@ -390,6 +338,59 @@ class TestFillingAutoFields():
         field = models.DummyEmptyModel._meta.get_field('id')
         assert isinstance(field, fields.AutoField)
         assert isinstance(obj.id, int)
+
+
+@pytest.mark.skipif(not models.has_pil, reason="PIL is required to test ImageField")
+class TestFillingImageFileField():
+
+    def test_filling_image_file_field(self, db):
+        dummy = mommy.make(models.DummyImageFieldModel, _create_files=True)
+        field = models.DummyImageFieldModel._meta.get_field('image_field')
+        assert isinstance(field, ImageField)
+        import time
+        path = "%s/%s/mock-img.jpeg" % (gettempdir(), time.strftime('%Y/%m/%d'))
+
+        # These require the file to exist in earlier versions of Django
+        assert abspath(path) == abspath(dummy.image_field.path)
+        assert dummy.image_field.width
+        assert dummy.image_field.height
+        dummy.image_field.delete()
+
+    def test_does_not_create_file_if_not_flagged(self, db):
+        dummy = mommy.make(models.DummyImageFieldModel)
+        with pytest.raises(ValueError):
+            dummy.image_field.path  # Django raises ValueError if file does not exist
+
+
+@pytest.mark.skipif(connection.vendor != 'postgresql', reason='PostgreSQL specific tests')
+class TestCIStringFieldsFilling:
+    def test_fill_cicharfield_with_a_random_str(self, person):
+        ci_char_field = models.Person._meta.get_field('ci_char')
+        assert isinstance(ci_char_field, CICharField)
+        assert isinstance(person.ci_char, str)
+        assert len(person.ci_char) == ci_char_field.max_length
+
+    def test_filling_ciemailfield(self, person):
+        ci_email_field = models.Person._meta.get_field('ci_email')
+        assert isinstance(ci_email_field, CIEmailField)
+        assert isinstance(person.ci_email, str)
+
+    def test_filling_citextfield(self, person):
+        ci_text_field = models.Person._meta.get_field('ci_text')
+        assert isinstance(ci_text_field, CITextField)
+        assert isinstance(person.ci_text, str)
+
+
+@pytest.mark.skipif(connection.vendor != 'postgresql', reason='PostgreSQL specific tests')
+class TestPostgreSQLFieldsFilling:
+    def test_fill_arrayfield_with_empty_array(self, person):
+        assert person.acquaintances == []
+
+    def test_fill_jsonfield_with_empty_dict(self, person):
+        assert person.data == {}
+
+    def test_fill_hstorefield_with_empty_dict(self, person):
+        assert person.hstore_data == {}
 
 
 @pytest.mark.skipif(not MOMMY_GIS, reason="GIS support required for GIS fields")

--- a/tests/test_mommy.py
+++ b/tests/test_mommy.py
@@ -386,9 +386,10 @@ class TestMommyCreatesAssociatedModels():
         assert 0 == models.RelatedNamesModel.objects.count()
 
 
+@pytest.mark.django_db
 class TestHandlingUnsupportedModels():
 
-    def test_unsupported_model_raises_an_explanatory_exception(self, db):
+    def test_unsupported_model_raises_an_explanatory_exception(self):
         try:
             mommy.make(models.UnsupportedModel)
             assert False, "Should have raised a TypeError"
@@ -396,28 +397,32 @@ class TestHandlingUnsupportedModels():
             assert 'not supported' in repr(e)
 
 
+@pytest.mark.django_db
 class TestHandlingModelsWithGenericRelationFields():
 
-    def test_create_model_with_generic_relation(self, db):
+    def test_create_model_with_generic_relation(self):
         dummy = mommy.make(models.DummyGenericRelationModel)
         assert isinstance(dummy, models.DummyGenericRelationModel)
 
 
+@pytest.mark.django_db
 class TestHandlingContentTypeField():
-    def test_create_model_with_contenttype_field(self, db):
+    def test_create_model_with_contenttype_field(self):
         dummy = mommy.make(models.DummyGenericForeignKeyModel)
         assert isinstance(dummy, models.DummyGenericForeignKeyModel)
 
 
+@pytest.mark.django_db
 class TestHandlingContentTypeFieldNoQueries():
-    def test_create_model_with_contenttype_field(self, db):
+    def test_create_model_with_contenttype_field(self):
         dummy = mommy.prepare(models.DummyGenericForeignKeyModel)
         assert isinstance(dummy, models.DummyGenericForeignKeyModel)
 
 
+@pytest.mark.django_db
 class TestSkipNullsTestCase():
 
-    def test_skip_null(self, db):
+    def test_skip_null(self):
         dummy = mommy.make(models.DummyNullFieldsModel)
         assert dummy.null_foreign_key is None
         assert dummy.null_integer_field is None
@@ -440,9 +445,10 @@ class TestFillNullsTestCase():
         assert classroom.students.count() == 0
 
 
+@pytest.mark.django_db
 class TestSkipBlanksTestCase():
 
-    def test_skip_blank(self, db):
+    def test_skip_blank(self):
         dummy = mommy.make(models.DummyBlankFieldsModel)
         assert dummy.blank_char_field == ''
         assert dummy.blank_text_field == ''
@@ -499,9 +505,10 @@ class TestFillAutoFieldsTestCase():
         assert saved_dummy.id == 543
 
 
+@pytest.mark.django_db
 class TestSkipDefaultsTestCase():
 
-    def test_skip_fields_with_default(self, db):
+    def test_skip_fields_with_default(self):
         dummy = mommy.make(models.DummyDefaultFieldsModel)
         assert dummy.default_char_field == 'default'
         assert dummy.default_text_field == 'default'
@@ -515,9 +522,10 @@ class TestSkipDefaultsTestCase():
         assert dummy.default_slug_field == 'a-slug'
 
 
+@pytest.mark.django_db
 class TestMommyHandlesModelWithNext():
 
-    def test_creates_instance_for_model_with_next(self, db):
+    def test_creates_instance_for_model_with_next(self):
         instance = mommy.make(
             models.BaseModelForNext,
             fk=mommy.make(models.ModelWithNext),
@@ -529,18 +537,20 @@ class TestMommyHandlesModelWithNext():
         assert 'foo' == instance.fk.next()
 
 
+@pytest.mark.django_db
 class TestMommyHandlesModelWithList():
 
-    def test_creates_instance_for_model_with_list(self, db):
+    def test_creates_instance_for_model_with_list(self):
         instance = mommy.make(models.BaseModelForList, fk=["foo"])
 
         assert instance.id
         assert ["foo"] == instance.fk
 
 
+@pytest.mark.django_db
 class TestMommyGeneratesIPAdresses():
 
-    def test_create_model_with_valid_ips(self, db):
+    def test_create_model_with_valid_ips(self):
         form_data = {
             'ipv4_field': random_gen.gen_ipv4(),
             'ipv6_field': random_gen.gen_ipv6(),
@@ -549,9 +559,10 @@ class TestMommyGeneratesIPAdresses():
         assert DummyGenericIPAddressFieldForm(form_data).is_valid()
 
 
+@pytest.mark.django_db
 class TestMommyAllowsSaveParameters():
 
-    def test_allows_save_kwargs_on_mommy_make(self, db):
+    def test_allows_save_kwargs_on_mommy_make(self):
         owner = mommy.make(models.Person)
         dog = mommy.make(models.ModelWithOverridedSave, _save_kwargs={'owner': owner})
         assert owner == dog.owner
@@ -586,9 +597,10 @@ class TestMommyAutomaticallyRefreshFromDB():
         assert person.birthday != datetime.date(2017, 2, 1)
 
 
+@pytest.mark.django_db
 class TestMommyMakeCanFetchInstanceFromDefaultManager():
 
-    def test_annotation_within_manager_get_queryset_are_run_on_make(self, db):
+    def test_annotation_within_manager_get_queryset_are_run_on_make(self):
         '''Test that a custom model Manager can be used within make().
 
         Passing _from_manager='objects' will force mommy.make() to

--- a/tests/test_mommy.py
+++ b/tests/test_mommy.py
@@ -289,7 +289,7 @@ class TestMommyCreatesAssociatedModels():
 
     def test_nullable_many_to_many_is_not_created_even_if_flagged(self):
         classroom = mommy.make(models.Classroom, make_m2m=True)
-        assert classroom.students.count() == 0
+        assert not classroom.students.count()
 
     def test_m2m_changed_signal_is_fired(self):
         # TODO: Use object attrs instead of mocks for Django 1.4 compat

--- a/tests/test_mommy.py
+++ b/tests/test_mommy.py
@@ -1,8 +1,8 @@
+import pytest
 import datetime
-
 from decimal import Decimal
+from unittest.mock import patch
 
-from django.test import TestCase, SimpleTestCase
 from django.db.models import Manager
 from django.db.models.signals import m2m_changed
 
@@ -14,39 +14,39 @@ from model_mommy.timezone import smart_datetime
 from tests.generic import models
 from tests.generic.forms import DummyGenericIPAddressFieldForm
 
-from unittest.mock import patch
 
+class TestsModelFinder():
 
-class ModelFinderTest(TestCase):
     def test_unicode_regression(self):
         obj = mommy.prepare('generic.Person')
-        self.assertIsInstance(obj, models.Person)
+        assert isinstance(obj, models.Person)
 
     def test_model_class(self):
         obj = mommy.prepare(models.Person)
-        self.assertIsInstance(obj, models.Person)
+        assert isinstance(obj, models.Person)
 
     def test_app_model_string(self):
         obj = mommy.prepare('generic.Person')
-        self.assertIsInstance(obj, models.Person)
+        assert isinstance(obj, models.Person)
 
     def test_model_string(self):
         obj = mommy.prepare('Person')
-        self.assertIsInstance(obj, models.Person)
+        assert isinstance(obj, models.Person)
 
     def test_raise_on_ambiguous_model_string(self):
-        with self.assertRaises(AmbiguousModelName):
+        with pytest.raises(AmbiguousModelName):
             mommy.prepare('Ambiguous')
 
     def test_raise_model_not_found(self):
-        with self.assertRaises(ModelNotFound):
+        with pytest.raises(ModelNotFound):
             mommy.Mommy('non_existing.Model')
 
-        with self.assertRaises(ModelNotFound):
+        with pytest.raises(ModelNotFound):
             mommy.Mommy('NonExistingModel')
 
 
-class MommyCreatesSimpleModel(TestCase):
+@pytest.mark.django_db
+class TestsMommyCreatesSimpleModel():
 
     def test_consider_real_django_fields_only(self):
         id_ = models.ModelWithImpostorField._meta.get_field('id')
@@ -57,130 +57,126 @@ class MommyCreatesSimpleModel(TestCase):
             try:
                 mommy.make(models.ModelWithImpostorField)
             except TypeError:
-                self.fail('TypeError raised')
+                assert False, 'TypeError raised'
 
     def test_make_should_create_one_object(self):
         person = mommy.make(models.Person)
-        self.assertIsInstance(person, models.Person)
+        assert isinstance(person, models.Person)
 
         # makes sure it is the person we created
-        self.assertTrue(models.Person.objects.filter(id=person.id))
+        assert models.Person.objects.filter(id=person.id).exists()
 
     def test_prepare_should_not_persist_one_object(self):
         person = mommy.prepare(models.Person)
-        self.assertIsInstance(person, models.Person)
+        assert isinstance(person, models.Person)
 
         # makes sure database is clean
-        self.assertEqual(models.Person.objects.all().count(), 0)
-
-        self.assertEqual(person.id, None)
+        assert not models.Person.objects.all().exists()
+        assert person.id is None
 
     def test_non_abstract_model_creation(self):
         person = mommy.make(models.NonAbstractPerson, name='bob', happy=False)
-        self.assertIsInstance(person, models.NonAbstractPerson)
-        self.assertEqual('bob', person.name)
-        self.assertFalse(person.happy)
+        assert isinstance(person, models.NonAbstractPerson)
+        assert 'bob' == person.name
+        assert person.happy is False
 
     def test_abstract_model_subclass_creation(self):
         instance = mommy.make(models.SubclassOfAbstract)
-        self.assertIsInstance(instance, models.SubclassOfAbstract)
-        self.assertIsInstance(instance, models.AbstractModel)
-        self.assertIsInstance(instance.name, type(u''))
-        self.assertEqual(len(instance.name), 30)
-        self.assertIsInstance(instance.height, int)
+        assert isinstance(instance, models.SubclassOfAbstract)
+        assert isinstance(instance, models.AbstractModel)
+        assert isinstance(instance.name, type(u''))
+        assert len(instance.name) == 30
+        assert isinstance(instance.height, int)
 
     def test_multiple_inheritance_creation(self):
         multiple = mommy.make(models.DummyMultipleInheritanceModel)
-        self.assertIsInstance(multiple, models.DummyMultipleInheritanceModel)
-        self.assertTrue(models.Person.objects.filter(id=multiple.id))
-        self.assertTrue(models.DummyDefaultFieldsModel.objects.filter(
+        assert isinstance(multiple, models.DummyMultipleInheritanceModel)
+        assert models.Person.objects.filter(id=multiple.id).exists()
+        assert models.DummyDefaultFieldsModel.objects.filter(
             default_id=multiple.default_id
-        ))
+        ).exists()
 
 
-class MommyRepeatedCreatesSimpleModel(TestCase):
+@pytest.mark.django_db
+class TestsMommyRepeatedCreatesSimpleModel():
 
     def test_make_should_create_objects_respecting_quantity_parameter(self):
         people = mommy.make(models.Person, _quantity=5)
-        self.assertEqual(models.Person.objects.count(), 5)
+        assert models.Person.objects.count() == 5
 
         people = mommy.make(models.Person, _quantity=5, name="George Washington")
-        self.assertTrue(all(p.name == "George Washington" for p in people))
+        assert all(p.name == "George Washington" for p in people)
 
     def test_make_raises_correct_exception_if_invalid_quantity(self):
-        self.assertRaises(
-            InvalidQuantityException, mommy.make, _model=models.Person, _quantity="hi"
-        )
-        self.assertRaises(
-            InvalidQuantityException, mommy.make, _model=models.Person, _quantity=-1
-        )
-        self.assertRaises(
-            InvalidQuantityException, mommy.make, _model=models.Person, _quantity=0
-        )
+        with pytest.raises(InvalidQuantityException):
+            mommy.make(_model=models.Person, _quantity="hi")
+        with pytest.raises(InvalidQuantityException):
+            mommy.make(_model=models.Person, _quantity=-1)
+        with pytest.raises(InvalidQuantityException):
+            mommy.make(_model=models.Person, _quantity=0)
 
     def test_prepare_should_create_objects_respecting_quantity_parameter(self):
         people = mommy.prepare(models.Person, _quantity=5)
-        self.assertEqual(len(people), 5)
-        self.assertTrue(all(not p.id for p in people))
+        assert len(people) == 5
+        assert all(not p.id for p in people)
 
         people = mommy.prepare(models.Person, _quantity=5, name="George Washington")
-        self.assertTrue(all(p.name == "George Washington" for p in people))
+        assert all(p.name == "George Washington" for p in people)
 
     def test_prepare_raises_correct_exception_if_invalid_quantity(self):
-        self.assertRaises(
-            InvalidQuantityException, mommy.prepare, _model=models.Person, _quantity="hi"
-        )
-        self.assertRaises(
-            InvalidQuantityException, mommy.prepare, _model=models.Person, _quantity=-1
-        )
-        self.assertRaises(
-            InvalidQuantityException, mommy.prepare, _model=models.Person, _quantity=0
-        )
+        with pytest.raises(InvalidQuantityException):
+            mommy.prepare(_model=models.Person, _quantity="hi")
+        with pytest.raises(InvalidQuantityException):
+            mommy.prepare(_model=models.Person, _quantity=-1)
+        with pytest.raises(InvalidQuantityException):
+            mommy.prepare(_model=models.Person, _quantity=0)
 
 
-class MommyPrepareSavingRelatedInstancesTests(TestCase):
+@pytest.mark.django_db
+class TestMommyPrepareSavingRelatedInstances():
 
     def test_default_behaviour_for_and_fk(self):
         dog = mommy.prepare(models.Dog)
 
-        self.assertIsNone(dog.pk)
-        self.assertIsNone(dog.owner.pk)
-        with self.assertRaises(ValueError):
+        assert dog.pk is None
+        assert dog.owner.pk is None
+        with pytest.raises(ValueError):
             dog.friends_with
 
     def test_create_fk_instances(self):
         dog = mommy.prepare(models.Dog, _save_related=True)
 
-        self.assertIsNone(dog.pk)
-        self.assertTrue(dog.owner.pk)
-        with self.assertRaises(ValueError):
+        assert dog.pk is None
+        assert dog.owner.pk
+        with pytest.raises(ValueError):
             dog.friends_with
 
     def test_create_fk_instances_with_quantity(self):
         dog1, dog2 = mommy.prepare(models.Dog, _save_related=True, _quantity=2)
 
-        self.assertIsNone(dog1.pk)
-        self.assertTrue(dog1.owner.pk)
-        with self.assertRaises(ValueError):
+        assert dog1.pk is None
+        assert dog1.owner.pk
+        with pytest.raises(ValueError):
             dog1.friends_with
 
-        self.assertIsNone(dog2.pk)
-        self.assertTrue(dog2.owner.pk)
-        with self.assertRaises(ValueError):
+        assert dog2.pk is None
+        assert dog2.owner.pk
+        with pytest.raises(ValueError):
             dog2.friends_with
 
     def test_create_one_to_one(self):
         lonely_person = mommy.prepare(models.LonelyPerson, _save_related=True)
 
-        self.assertIsNone(lonely_person.pk)
-        self.assertTrue(lonely_person.only_friend.pk)
+        assert lonely_person.pk is None
+        assert lonely_person.only_friend.pk
 
 
-class MommyCreatesAssociatedModels(TestCase):
+@pytest.mark.django_db
+class TestMommyCreatesAssociatedModels():
 
     def test_dependent_models_with_ForeignKey(self):
         dog = mommy.make(models.Dog)
-        self.assertIsInstance(dog.owner, models.Person)
+        assert isinstance(dog.owner, models.Person)
 
     def test_foreign_key_on_parent_should_create_one_object(self):
         '''
@@ -189,7 +185,7 @@ class MommyCreatesAssociatedModels(TestCase):
         '''
         person_count = models.Person.objects.count()
         mommy.make(models.GuardDog)
-        self.assertEqual(models.Person.objects.count(), person_count + 1)
+        assert models.Person.objects.count() == person_count + 1
 
     def test_foreign_key_on_parent_is_not_created(self):
         '''
@@ -198,8 +194,8 @@ class MommyCreatesAssociatedModels(TestCase):
         owner = mommy.make(models.Person)
         person_count = models.Person.objects.count()
         dog = mommy.make(models.GuardDog, owner=owner)
-        self.assertEqual(models.Person.objects.count(), person_count)
-        self.assertEqual(dog.owner, owner)
+        assert models.Person.objects.count() == person_count
+        assert dog.owner == owner
 
     def test_foreign_key_on_parent_id_is_not_created(self):
         '''
@@ -208,8 +204,8 @@ class MommyCreatesAssociatedModels(TestCase):
         owner = mommy.make(models.Person)
         person_count = models.Person.objects.count()
         dog = mommy.make(models.GuardDog, owner_id=owner.id)
-        self.assertEqual(models.Person.objects.count(), person_count)
-        self.assertEqual(models.GuardDog.objects.get(pk=dog.pk).owner, owner)
+        assert models.Person.objects.count() == person_count
+        assert models.GuardDog.objects.get(pk=dog.pk).owner == owner
 
     def test_auto_now_add_on_parent_should_work(self):
         '''
@@ -218,8 +214,8 @@ class MommyCreatesAssociatedModels(TestCase):
         '''
         person_count = models.Person.objects.count()
         dog = mommy.make(models.GuardDog)
-        self.assertEqual(models.Person.objects.count(), person_count + 1)
-        self.assertNotEqual(dog.created, None)
+        assert models.Person.objects.count() == person_count + 1
+        assert dog.created
 
     def test_attrs_on_related_model_through_parent(self):
         '''
@@ -228,33 +224,33 @@ class MommyCreatesAssociatedModels(TestCase):
         '''
         mommy.make(models.GuardDog, owner__name='john')
         for person in models.Person.objects.all():
-            self.assertEqual(person.name, 'john')
+            assert person.name == 'john'
 
     def test_access_related_name_of_m2m(self):
         try:
             mommy.make(models.Person, classroom_set=[mommy.make(models.Classroom)])
         except TypeError:
-            self.fail('type error raised')
+            assert False, 'type error raised'
 
     def test_prepare_fk(self):
         dog = mommy.prepare(models.Dog)
-        self.assertIsInstance(dog, models.Dog)
-        self.assertIsInstance(dog.owner, models.Person)
+        assert isinstance(dog, models.Dog)
+        assert isinstance(dog.owner, models.Person)
 
-        self.assertEqual(models.Person.objects.all().count(), 0)
-        self.assertEqual(models.Dog.objects.all().count(), 0)
+        assert models.Person.objects.all().count() == 0
+        assert models.Dog.objects.all().count() == 0
 
     def test_create_one_to_one(self):
         lonely_person = mommy.make(models.LonelyPerson)
 
-        self.assertEqual(models.LonelyPerson.objects.all().count(), 1)
-        self.assertTrue(isinstance(lonely_person.only_friend, models.Person))
-        self.assertEqual(models.Person.objects.all().count(), 1)
+        assert models.LonelyPerson.objects.all().count() == 1
+        assert isinstance(lonely_person.only_friend, models.Person)
+        assert models.Person.objects.all().count() == 1
 
     def test_create_many_to_many_if_flagged(self):
         store = mommy.make(models.Store, make_m2m=True)
-        self.assertEqual(store.employees.count(), 5)
-        self.assertEqual(store.customers.count(), 5)
+        assert store.employees.count() == 5
+        assert store.customers.count() == 5
 
     def test_regresstion_many_to_many_field_is_accepted_as_kwargs(self):
         employees = mommy.make(models.Person, _quantity=3)
@@ -262,14 +258,14 @@ class MommyCreatesAssociatedModels(TestCase):
 
         store = mommy.make(models.Store, employees=employees, customers=customers)
 
-        self.assertEqual(store.employees.count(), 3)
-        self.assertEqual(store.customers.count(), 3)
-        self.assertEqual(models.Person.objects.count(), 6)
+        assert store.employees.count() == 3
+        assert store.customers.count() == 3
+        assert models.Person.objects.count() == 6
 
     def test_create_many_to_many_with_set_default_quantity(self):
         store = mommy.make(models.Store, make_m2m=True)
-        self.assertEqual(store.employees.count(), mommy.MAX_MANY_QUANTITY)
-        self.assertEqual(store.customers.count(), mommy.MAX_MANY_QUANTITY)
+        assert store.employees.count() == mommy.MAX_MANY_QUANTITY
+        assert store.customers.count() == mommy.MAX_MANY_QUANTITY
 
     def test_create_many_to_many_with_through_option(self):
         """
@@ -277,23 +273,23 @@ class MommyCreatesAssociatedModels(TestCase):
         """
         # School student's attr is a m2m relationship with a model through
         school = mommy.make(models.School, make_m2m=True)
-        self.assertEqual(models.School.objects.count(), 1)
-        self.assertEqual(school.students.count(), mommy.MAX_MANY_QUANTITY)
-        self.assertEqual(models.SchoolEnrollment.objects.count(), mommy.MAX_MANY_QUANTITY)
-        self.assertEqual(models.Person.objects.count(), mommy.MAX_MANY_QUANTITY)
+        assert models.School.objects.count() == 1
+        assert school.students.count() == mommy.MAX_MANY_QUANTITY
+        assert models.SchoolEnrollment.objects.count() == mommy.MAX_MANY_QUANTITY
+        assert models.Person.objects.count() == mommy.MAX_MANY_QUANTITY
 
     def test_does_not_create_many_to_many_as_default(self):
         store = mommy.make(models.Store)
-        self.assertEqual(store.employees.count(), 0)
-        self.assertEqual(store.customers.count(), 0)
+        assert store.employees.count() == 0
+        assert store.customers.count() == 0
 
     def test_does_not_create_nullable_many_to_many_for_relations(self):
         classroom = mommy.make(models.Classroom, make_m2m=False)
-        self.assertEqual(classroom.students.count(), 0)
+        assert classroom.students.count() == 0
 
     def test_nullable_many_to_many_is_not_created_even_if_flagged(self):
         classroom = mommy.make(models.Classroom, make_m2m=True)
-        self.assertEqual(classroom.students.count(), 0)
+        assert classroom.students.count() == 0
 
     def test_m2m_changed_signal_is_fired(self):
         # TODO: Use object attrs instead of mocks for Django 1.4 compat
@@ -304,67 +300,67 @@ class MommyCreatesAssociatedModels(TestCase):
 
         m2m_changed.connect(test_m2m_changed, dispatch_uid='test_m2m_changed')
         mommy.make(models.Store, make_m2m=True)
-        self.assertTrue(self.m2m_changed_fired)
+        assert self.m2m_changed_fired
 
     def test_simple_creating_person_with_parameters(self):
         kid = mommy.make(models.Person, happy=True, age=10, name='Mike')
-        self.assertEqual(kid.age, 10)
-        self.assertEqual(kid.happy, True)
-        self.assertEqual(kid.name, 'Mike')
+        assert kid.age == 10
+        assert kid.happy == True
+        assert kid.name == 'Mike'
 
     def test_creating_person_from_factory_using_paramters(self):
         person_mom = mommy.Mommy(models.Person)
         person = person_mom.make(happy=False, age=20, gender='M', name='John')
-        self.assertEqual(person.age, 20)
-        self.assertEqual(person.happy, False)
-        self.assertEqual(person.name, 'John')
-        self.assertEqual(person.gender, 'M')
+        assert person.age == 20
+        assert person.happy == False
+        assert person.name == 'John'
+        assert person.gender == 'M'
 
     def test_ForeignKey_model_field_population(self):
         dog = mommy.make(models.Dog, breed='X1', owner__name='Bob')
-        self.assertEqual('X1', dog.breed)
-        self.assertEqual('Bob', dog.owner.name)
+        assert 'X1' == dog.breed
+        assert 'Bob' == dog.owner.name
 
     def test_ForeignKey_model_field_population_should_work_with_prepare(self):
         dog = mommy.prepare(models.Dog, breed='X1', owner__name='Bob')
-        self.assertEqual('X1', dog.breed)
-        self.assertEqual('Bob', dog.owner.name)
+        assert 'X1' == dog.breed
+        assert 'Bob' == dog.owner.name
 
     def test_ForeignKey_model_field_population_for_not_required_fk(self):
         user = mommy.make(models.User, profile__email="a@b.com")
-        self.assertEqual('a@b.com', user.profile.email)
+        assert 'a@b.com' == user.profile.email
 
     def test_does_not_creates_null_ForeignKey(self):
         user = mommy.make(models.User)
-        self.assertFalse(user.profile)
+        assert not user.profile
 
     def test_passing_m2m_value(self):
         store = mommy.make(models.Store, customers=[mommy.make(models.Person)])
-        self.assertEqual(store.customers.count(), 1)
+        assert store.customers.count() == 1
 
     def test_ensure_recursive_ForeignKey_population(self):
         bill = mommy.make(models.PaymentBill, user__profile__email="a@b.com")
-        self.assertEqual('a@b.com', bill.user.profile.email)
+        assert 'a@b.com' == bill.user.profile.email
 
     def test_field_lookup_for_m2m_relationship(self):
         store = mommy.make(models.Store, suppliers__gender='M')
         suppliers = store.suppliers.all()
-        self.assertTrue(suppliers)
+        assert suppliers
         for supplier in suppliers:
-            self.assertEqual('M', supplier.gender)
+            assert 'M' == supplier.gender
 
     def test_field_lookup_for_one_to_one_relationship(self):
         lonely_person = mommy.make(models.LonelyPerson, only_friend__name='Bob')
-        self.assertEqual('Bob', lonely_person.only_friend.name)
+        assert 'Bob' == lonely_person.only_friend.name
 
     def test_allow_create_fkey_related_model(self):
         try:
             person = mommy.make(models.Person, dog_set=[mommy.make(models.Dog),
                                                         mommy.make(models.Dog)])
         except TypeError:
-            self.fail('type error raised')
+            assert False, 'type error raised'
 
-        self.assertEqual(person.dog_set.count(), 2)
+        assert person.dog_set.count() == 2
 
     def test_field_lookup_for_related_field(self):
         person = mommy.make(
@@ -373,11 +369,11 @@ class MommyCreatesAssociatedModels(TestCase):
             fk_related__name='Bar',
         )
 
-        self.assertTrue(person.pk)
-        self.assertTrue(person.one_related.pk)
-        self.assertTrue(1, person.fk_related.count())
-        self.assertEqual('Foo', person.one_related.name)
-        self.assertEqual('Bar', person.fk_related.get().name)
+        assert person.pk
+        assert person.one_related.pk
+        assert 1, person.fk_related.count()
+        assert 'Foo' == person.one_related.name
+        assert 'Bar' == person.fk_related.get().name
 
     def test_field_lookup_for_related_field_does_not_work_with_prepare(self):
         person = mommy.prepare(
@@ -386,80 +382,88 @@ class MommyCreatesAssociatedModels(TestCase):
             fk_related__name='Bar',
         )
 
-        self.assertFalse(person.pk)
-        self.assertEqual(0, models.RelatedNamesModel.objects.count())
+        assert not person.pk
+        assert 0 == models.RelatedNamesModel.objects.count()
 
 
-class HandlingUnsupportedModels(TestCase):
-    def test_unsupported_model_raises_an_explanatory_exception(self):
+class TestHandlingUnsupportedModels():
+
+    def test_unsupported_model_raises_an_explanatory_exception(self, db):
         try:
             mommy.make(models.UnsupportedModel)
-            self.fail("Should have raised a TypeError")
+            assert False, "Should have raised a TypeError"
         except TypeError as e:
-            self.assertTrue('not supported' in repr(e))
+            assert 'not supported' in repr(e)
 
 
-class HandlingModelsWithGenericRelationFields(TestCase):
-    def test_create_model_with_generic_relation(self):
+class TestHandlingModelsWithGenericRelationFields():
+
+    def test_create_model_with_generic_relation(self, db):
         dummy = mommy.make(models.DummyGenericRelationModel)
-        self.assertIsInstance(dummy, models.DummyGenericRelationModel)
+        assert isinstance(dummy, models.DummyGenericRelationModel)
 
 
-class HandlingContentTypeField(TestCase):
-    def test_create_model_with_contenttype_field(self):
+class TestHandlingContentTypeField():
+    def test_create_model_with_contenttype_field(self, db):
         dummy = mommy.make(models.DummyGenericForeignKeyModel)
-        self.assertIsInstance(dummy, models.DummyGenericForeignKeyModel)
+        assert isinstance(dummy, models.DummyGenericForeignKeyModel)
 
 
-class HandlingContentTypeFieldNoQueries(SimpleTestCase):
-    def test_create_model_with_contenttype_field(self):
+class TestHandlingContentTypeFieldNoQueries():
+    def test_create_model_with_contenttype_field(self, db):
         dummy = mommy.prepare(models.DummyGenericForeignKeyModel)
-        self.assertIsInstance(dummy, models.DummyGenericForeignKeyModel)
+        assert isinstance(dummy, models.DummyGenericForeignKeyModel)
 
 
-class SkipNullsTestCase(TestCase):
-    def test_skip_null(self):
+class TestSkipNullsTestCase():
+
+    def test_skip_null(self, db):
         dummy = mommy.make(models.DummyNullFieldsModel)
-        self.assertEqual(dummy.null_foreign_key, None)
-        self.assertEqual(dummy.null_integer_field, None)
+        assert dummy.null_foreign_key is None
+        assert dummy.null_integer_field is None
 
 
-class FillNullsTestCase(TestCase):
+@pytest.mark.django_db
+class TestFillNullsTestCase():
+
     def test_create_nullable_many_to_many_if_flagged_and_fill_field_optional(self):
         classroom = mommy.make(models.Classroom, make_m2m=True, _fill_optional=[
             'students'])
-        self.assertEqual(classroom.students.count(), 5)
+        assert classroom.students.count() == 5
 
     def test_create_nullable_many_to_many_if_flagged_and_fill_optional(self):
         classroom = mommy.make(models.Classroom, make_m2m=True, _fill_optional=True)
-        self.assertEqual(classroom.students.count(), 5)
+        assert classroom.students.count() == 5
 
     def test_nullable_many_to_many_is_not_created_if_not_flagged_and_fill_optional(self):
         classroom = mommy.make(models.Classroom, make_m2m=False, _fill_optional=True)
-        self.assertEqual(classroom.students.count(), 0)
+        assert classroom.students.count() == 0
 
 
-class SkipBlanksTestCase(TestCase):
-    def test_skip_blank(self):
+class TestSkipBlanksTestCase():
+
+    def test_skip_blank(self, db):
         dummy = mommy.make(models.DummyBlankFieldsModel)
-        self.assertEqual(dummy.blank_char_field, '')
-        self.assertEqual(dummy.blank_text_field, '')
+        assert dummy.blank_char_field == ''
+        assert dummy.blank_text_field == ''
 
 
-class FillBlanksTestCase(TestCase):
+@pytest.mark.django_db
+class TestFillBlanksTestCase():
+
     def test_fill_field_optional(self):
         dummy = mommy.make(models.DummyBlankFieldsModel, _fill_optional=['blank_char_field'])
-        self.assertEqual(len(dummy.blank_char_field), 50)
+        assert len(dummy.blank_char_field) == 50
 
     def test_fill_wrong_field(self):
-        with self.assertRaisesMessage(
-            AttributeError, "_fill_optional field(s) ['wrong'] are not "
-                            "related to model DummyBlankFieldsModel"
-        ):
+        with pytest.raises(AttributeError) as exc_info:
             mommy.make(models.DummyBlankFieldsModel,_fill_optional=['blank_char_field', 'wrong'])
 
+        msg = "_fill_optional field(s) ['wrong'] are not related to model DummyBlankFieldsModel"
+        assert msg in str(exc_info.value)
+
     def test_fill_wrong_fields_with_parent(self):
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             mommy.make(models.SubclassOfAbstract, _fill_optional=['name', 'wrong'])
 
     def test_fill_many_optional(self):
@@ -467,121 +471,124 @@ class FillBlanksTestCase(TestCase):
             models.DummyBlankFieldsModel,
             _fill_optional=['blank_char_field', 'blank_text_field']
         )
-        self.assertEqual(len(dummy.blank_text_field), 300)
+        assert len(dummy.blank_text_field) == 300
 
     def test_fill_all_optional(self):
         dummy = mommy.make(models.DummyBlankFieldsModel, _fill_optional=True)
-        self.assertEqual(len(dummy.blank_char_field), 50)
-        self.assertEqual(len(dummy.blank_text_field), 300)
+        assert len(dummy.blank_char_field) == 50
+        assert len(dummy.blank_text_field) == 300
 
     def test_fill_optional_with_integer(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             mommy.make(models.DummyBlankFieldsModel, _fill_optional=1)
 
 
-class FillAutoFieldsTestCase(TestCase):
+@pytest.mark.django_db
+class TestFillAutoFieldsTestCase():
 
     def test_fill_autofields_with_provided_value(self):
         mommy.make(models.DummyEmptyModel, id=237)
         saved_dummy = models.DummyEmptyModel.objects.get()
-        self.assertEqual(saved_dummy.id, 237)
+        assert saved_dummy.id == 237
 
     def test_keeps_prepare_autovalues(self):
         dummy = mommy.prepare(models.DummyEmptyModel, id=543)
-        self.assertEqual(dummy.id, 543)
+        assert dummy.id == 543
         dummy.save()
         saved_dummy = models.DummyEmptyModel.objects.get()
-        self.assertEqual(saved_dummy.id, 543)
+        assert saved_dummy.id == 543
 
 
-class SkipDefaultsTestCase(TestCase):
-    def test_skip_fields_with_default(self):
+class TestSkipDefaultsTestCase():
+
+    def test_skip_fields_with_default(self, db):
         dummy = mommy.make(models.DummyDefaultFieldsModel)
-        self.assertEqual(dummy.default_char_field, 'default')
-        self.assertEqual(dummy.default_text_field, 'default')
-        self.assertEqual(dummy.default_int_field, 123)
-        self.assertEqual(dummy.default_float_field, 123.0)
-        self.assertEqual(dummy.default_date_field, '2012-01-01')
-        self.assertEqual(dummy.default_date_time_field, smart_datetime(2012, 1, 1))
-        self.assertEqual(dummy.default_time_field, '00:00:00')
-        self.assertEqual(dummy.default_decimal_field, Decimal('0'))
-        self.assertEqual(dummy.default_email_field, 'foo@bar.org')
-        self.assertEqual(dummy.default_slug_field, 'a-slug')
+        assert dummy.default_char_field == 'default'
+        assert dummy.default_text_field == 'default'
+        assert dummy.default_int_field == 123
+        assert dummy.default_float_field == 123.0
+        assert dummy.default_date_field == '2012-01-01'
+        assert dummy.default_date_time_field == smart_datetime(2012, 1, 1)
+        assert dummy.default_time_field == '00:00:00'
+        assert dummy.default_decimal_field == Decimal('0')
+        assert dummy.default_email_field == 'foo@bar.org'
+        assert dummy.default_slug_field == 'a-slug'
 
 
-class MommyHandlesModelWithNext(TestCase):
-    def test_creates_instance_for_model_with_next(self):
+class TestMommyHandlesModelWithNext():
+
+    def test_creates_instance_for_model_with_next(self, db):
         instance = mommy.make(
             models.BaseModelForNext,
             fk=mommy.make(models.ModelWithNext),
         )
 
-        self.assertTrue(instance.id)
-        self.assertTrue(instance.fk.id)
-        self.assertTrue(instance.fk.attr)
-        self.assertEqual('foo', instance.fk.next())
+        assert instance.id
+        assert instance.fk.id
+        assert instance.fk.attr
+        assert 'foo' == instance.fk.next()
 
 
-class MommyHandlesModelWithList(TestCase):
-    def test_creates_instance_for_model_with_list(self):
-        instance = mommy.make(
-            models.BaseModelForList,
-            fk=["foo"]
-        )
+class TestMommyHandlesModelWithList():
 
-        self.assertTrue(instance.id)
-        self.assertEqual(["foo"], instance.fk)
+    def test_creates_instance_for_model_with_list(self, db):
+        instance = mommy.make(models.BaseModelForList, fk=["foo"])
+
+        assert instance.id
+        assert ["foo"] == instance.fk
 
 
-class MommyGeneratesIPAdresses(TestCase):
-    def test_create_model_with_valid_ips(self):
+class TestMommyGeneratesIPAdresses():
+
+    def test_create_model_with_valid_ips(self, db):
         form_data = {
             'ipv4_field': random_gen.gen_ipv4(),
             'ipv6_field': random_gen.gen_ipv6(),
             'ipv46_field': random_gen.gen_ipv46(),
         }
-        self.assertTrue(DummyGenericIPAddressFieldForm(form_data).is_valid())
+        assert DummyGenericIPAddressFieldForm(form_data).is_valid()
 
 
-class MommyAllowsSaveParameters(TestCase):
-    def setUp(self):
-        self.owner = mommy.make(models.Person)
+class TestMommyAllowsSaveParameters():
 
-    def test_allows_save_kwargs_on_mommy_make(self):
-        dog = mommy.make(models.ModelWithOverridedSave, _save_kwargs={'owner': self.owner})
-        self.assertEqual(self.owner, dog.owner)
+    def test_allows_save_kwargs_on_mommy_make(self, db):
+        owner = mommy.make(models.Person)
+        dog = mommy.make(models.ModelWithOverridedSave, _save_kwargs={'owner': owner})
+        assert owner == dog.owner
 
         dog1, dog2 = mommy.make(
             models.ModelWithOverridedSave,
-            _save_kwargs={'owner': self.owner},
+            _save_kwargs={'owner': owner},
             _quantity=2
         )
-        self.assertEqual(self.owner, dog1.owner)
-        self.assertEqual(self.owner, dog2.owner)
+        assert owner == dog1.owner
+        assert owner == dog2.owner
 
 
-class MommyAutomaticallyRefreshFromDB(TestCase):
+@pytest.mark.django_db
+class TestMommyAutomaticallyRefreshFromDB():
+
     def test_refresh_from_db_if_true(self):
         person = mommy.make(models.Person, birthday='2017-02-01', _refresh_after_create=True)
 
-        self.assertEqual(person.birthday, datetime.date(2017, 2, 1))
+        assert person.birthday == datetime.date(2017, 2, 1)
 
     def test_do_not_refresh_from_db_if_false(self):
         person = mommy.make(models.Person, birthday='2017-02-01', _refresh_after_create=False)
 
-        self.assertEqual(person.birthday, '2017-02-01')
-        self.assertNotEqual(person.birthday, datetime.date(2017, 2, 1))
+        assert person.birthday == '2017-02-01'
+        assert person.birthday != datetime.date(2017, 2, 1)
 
     def test_do_not_refresh_from_db_by_default(self):
         person = mommy.make(models.Person, birthday='2017-02-01')
 
-        self.assertEqual(person.birthday, '2017-02-01')
-        self.assertNotEqual(person.birthday, datetime.date(2017, 2, 1))
+        assert person.birthday == '2017-02-01'
+        assert person.birthday != datetime.date(2017, 2, 1)
 
 
-class MommyMakeCanFetchInstanceFromDefaultManager(TestCase):
+class TestMommyMakeCanFetchInstanceFromDefaultManager():
 
-    def test_annotation_within_manager_get_queryset_are_run_on_make(self):
+    def test_annotation_within_manager_get_queryset_are_run_on_make(self, db):
         '''Test that a custom model Manager can be used within make().
 
         Passing _from_manager='objects' will force mommy.make() to
@@ -592,7 +599,7 @@ class MommyMakeCanFetchInstanceFromDefaultManager(TestCase):
 
         '''
         movie = mommy.make(models.MovieWithAnnotation)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             movie.name
 
         movie = mommy.make(
@@ -600,4 +607,4 @@ class MommyMakeCanFetchInstanceFromDefaultManager(TestCase):
             title='Old Boy',
             _from_manager='objects',
         )
-        self.assertEqual(movie.title, movie.name)
+        assert movie.title == movie.name

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,9 +1,9 @@
+import pytest
 import itertools
 from random import choice
 from decimal import Decimal
 from unittest.mock import patch
 
-from django.test import TestCase
 from datetime import timedelta
 from model_mommy import mommy
 from model_mommy.recipe import Recipe, foreign_key, RecipeForeignKey
@@ -12,24 +12,21 @@ from model_mommy.exceptions import InvalidQuantityException, RecipeIteratorEmpty
 from tests.generic.models import TEST_TIME, Person, DummyNumbersModel, DummyBlankFieldsModel, Dog
 from tests.generic.mommy_recipes import SmallDogRecipe, pug
 
+recipe_attrs = {
+    'name': 'John Doe',
+    'nickname': 'joe',
+    'age': 18,
+    'bio': 'Someone in the crowd',
+    'birthday': now().date(),
+    'appointment': now(),
+    'blog': 'http://joe.blogspot.com',
+    'wanted_games_qtd': 4,
+    'birth_time': now()
+}
+person_recipe = Recipe(Person, **recipe_attrs)
 
-class TestDefiningRecipes(TestCase):
-    def setUp(self):
-        self.recipe_attrs = {
-          'name': 'John Doe',
-          'nickname': 'joe',
-          'age': 18,
-          'bio': 'Someone in the crowd',
-          'birthday': now().date(),
-          'appointment': now(),
-          'blog': 'http://joe.blogspot.com',
-          'wanted_games_qtd': 4,
-          'birth_time': now()
-        }
-        self.person_recipe = Recipe(
-          Person,
-          **self.recipe_attrs
-        )
+@pytest.mark.django_db
+class TestDefiningRecipes():
 
     def test_import_seq_from_mommy(self):
         """
@@ -45,28 +42,28 @@ class TestDefiningRecipes(TestCase):
           A 'flat model' means a model without associations, like
           foreign keys, many to many and one to one
         """
-        person = self.person_recipe.make()
-        self.assertEqual(person.name, self.recipe_attrs['name'])
-        self.assertEqual(person.nickname, self.recipe_attrs['nickname'])
-        self.assertEqual(person.age, self.recipe_attrs['age'])
-        self.assertEqual(person.bio, self.recipe_attrs['bio'])
-        self.assertEqual(person.birthday, self.recipe_attrs['birthday'])
-        self.assertEqual(person.appointment, self.recipe_attrs['appointment'])
-        self.assertEqual(person.blog, self.recipe_attrs['blog'])
-        self.assertEqual(person.wanted_games_qtd, self.recipe_attrs['wanted_games_qtd'])
-        self.assertNotEqual(person.id, None)
+        person = person_recipe.make()
+        assert person.name == recipe_attrs['name']
+        assert person.nickname == recipe_attrs['nickname']
+        assert person.age == recipe_attrs['age']
+        assert person.bio == recipe_attrs['bio']
+        assert person.birthday == recipe_attrs['birthday']
+        assert person.appointment == recipe_attrs['appointment']
+        assert person.blog == recipe_attrs['blog']
+        assert person.wanted_games_qtd == recipe_attrs['wanted_games_qtd']
+        assert person.id is not None
 
     def test_flat_model_prepare_recipe_with_the_correct_attributes(self):
-        person = self.person_recipe.prepare()
-        self.assertEqual(person.name, self.recipe_attrs['name'])
-        self.assertEqual(person.nickname, self.recipe_attrs['nickname'])
-        self.assertEqual(person.age, self.recipe_attrs['age'])
-        self.assertEqual(person.bio, self.recipe_attrs['bio'])
-        self.assertEqual(person.birthday, self.recipe_attrs['birthday'])
-        self.assertEqual(person.appointment, self.recipe_attrs['appointment'])
-        self.assertEqual(person.blog, self.recipe_attrs['blog'])
-        self.assertEqual(person.wanted_games_qtd, self.recipe_attrs['wanted_games_qtd'])
-        self.assertEqual(person.id, None)
+        person = person_recipe.prepare()
+        assert person.name == recipe_attrs['name']
+        assert person.nickname == recipe_attrs['nickname']
+        assert person.age == recipe_attrs['age']
+        assert person.bio == recipe_attrs['bio']
+        assert person.birthday == recipe_attrs['birthday']
+        assert person.appointment == recipe_attrs['appointment']
+        assert person.blog == recipe_attrs['blog']
+        assert person.wanted_games_qtd == recipe_attrs['wanted_games_qtd']
+        assert person.id is None
 
     def test_accepts_callable(self):
         r = Recipe(
@@ -74,7 +71,7 @@ class TestDefiningRecipes(TestCase):
             blank_char_field=lambda: 'callable!!'
         )
         value = r.make().blank_char_field
-        self.assertEqual(value, 'callable!!')
+        assert value == 'callable!!'
 
     def test_always_calls_when_creating(self):
         with patch('tests.test_recipes.choice') as choice_mock:
@@ -86,7 +83,7 @@ class TestDefiningRecipes(TestCase):
             )
             r.make().blank_char_field
             r.make().blank_char_field
-            self.assertEqual(choice_mock.call_count, 2)
+            assert choice_mock.call_count == 2
 
     def test_always_calls_with_quantity(self):
         with patch('tests.test_recipes.choice') as choice_mock:
@@ -97,71 +94,71 @@ class TestDefiningRecipes(TestCase):
                 blank_char_field=lambda: choice_mock(lst)
             )
             r.make(_quantity=3)
-            self.assertEqual(choice_mock.call_count, 3)
+            assert choice_mock.call_count == 3
 
     def test_make_recipes_with_args(self):
         """
           Overriding some fields values at recipe execution
         """
-        person = self.person_recipe.make(name='Guido', age=56)
-        self.assertNotEqual(person.name, self.recipe_attrs['name'])
-        self.assertEqual(person.name, 'Guido')
+        person = person_recipe.make(name='Guido', age=56)
+        assert person.name != recipe_attrs['name']
+        assert person.name == 'Guido'
 
-        self.assertNotEqual(person.age, self.recipe_attrs['age'])
-        self.assertEqual(person.age, 56)
+        assert person.age != recipe_attrs['age']
+        assert person.age == 56
 
-        self.assertEqual(person.nickname, self.recipe_attrs['nickname'])
-        self.assertEqual(person.bio, self.recipe_attrs['bio'])
-        self.assertEqual(person.birthday, self.recipe_attrs['birthday'])
-        self.assertEqual(person.appointment, self.recipe_attrs['appointment'])
-        self.assertEqual(person.blog, self.recipe_attrs['blog'])
-        self.assertEqual(person.wanted_games_qtd, self.recipe_attrs['wanted_games_qtd'])
-        self.assertNotEqual(person.id, None)
+        assert person.nickname == recipe_attrs['nickname']
+        assert person.bio == recipe_attrs['bio']
+        assert person.birthday == recipe_attrs['birthday']
+        assert person.appointment == recipe_attrs['appointment']
+        assert person.blog == recipe_attrs['blog']
+        assert person.wanted_games_qtd == recipe_attrs['wanted_games_qtd']
+        assert person.id is not None
 
     def test_prepare_recipes_with_args(self):
         """
           Overriding some fields values at recipe execution
         """
-        person = self.person_recipe.prepare(name='Guido', age=56)
-        self.assertNotEqual(person.name, self.recipe_attrs['name'])
-        self.assertEqual(person.name, 'Guido')
+        person = person_recipe.prepare(name='Guido', age=56)
+        assert person.name != recipe_attrs['name']
+        assert person.name == 'Guido'
 
-        self.assertNotEqual(person.age, self.recipe_attrs['age'])
-        self.assertEqual(person.age, 56)
+        assert person.age != recipe_attrs['age']
+        assert person.age == 56
 
-        self.assertEqual(person.nickname, self.recipe_attrs['nickname'])
-        self.assertEqual(person.bio, self.recipe_attrs['bio'])
-        self.assertEqual(person.birthday, self.recipe_attrs['birthday'])
-        self.assertEqual(person.appointment, self.recipe_attrs['appointment'])
-        self.assertEqual(person.blog, self.recipe_attrs['blog'])
-        self.assertEqual(person.wanted_games_qtd, self.recipe_attrs['wanted_games_qtd'])
-        self.assertEqual(person.id, None)
+        assert person.nickname == recipe_attrs['nickname']
+        assert person.bio == recipe_attrs['bio']
+        assert person.birthday == recipe_attrs['birthday']
+        assert person.appointment == recipe_attrs['appointment']
+        assert person.blog == recipe_attrs['blog']
+        assert person.wanted_games_qtd == recipe_attrs['wanted_games_qtd']
+        assert person.id == None
 
     def test_make_recipe_without_all_model_needed_data(self):
         person_recipe = Recipe(Person, name='John Doe')
         person = person_recipe.make()
-        self.assertEqual('John Doe', person.name)
-        self.assertTrue(person.nickname)
-        self.assertTrue(person.age)
-        self.assertTrue(person.bio)
-        self.assertTrue(person.birthday)
-        self.assertTrue(person.appointment)
-        self.assertTrue(person.blog)
-        self.assertTrue(person.wanted_games_qtd)
-        self.assertTrue(person.id)
+        assert 'John Doe' == person.name
+        assert person.nickname
+        assert person.age
+        assert person.bio
+        assert person.birthday
+        assert person.appointment
+        assert person.blog
+        assert person.wanted_games_qtd
+        assert person.id
 
     def test_prepare_recipe_without_all_model_needed_data(self):
         person_recipe = Recipe(Person, name='John Doe')
         person = person_recipe.prepare()
-        self.assertEqual('John Doe', person.name)
-        self.assertTrue(person.nickname)
-        self.assertTrue(person.age)
-        self.assertTrue(person.bio)
-        self.assertTrue(person.birthday)
-        self.assertTrue(person.appointment)
-        self.assertTrue(person.blog)
-        self.assertTrue(person.wanted_games_qtd)
-        self.assertFalse(person.id)
+        assert 'John Doe' == person.name
+        assert person.nickname
+        assert person.age
+        assert person.bio
+        assert person.birthday
+        assert person.appointment
+        assert person.blog
+        assert person.wanted_games_qtd
+        assert not person.id
 
     def test_defining_recipes_str(self):
         from model_mommy.recipe import seq
@@ -175,84 +172,85 @@ class TestDefiningRecipes(TestCase):
             self.fail('%s' % e)
 
 
-class TestExecutingRecipes(TestCase):
+@pytest.mark.django_db
+class TestExecutingRecipes():
     """
       Tests for calling recipes defined in mommy_recipes.py
     """
     def test_model_with_foreign_key(self):
         dog = mommy.make_recipe('tests.generic.dog')
-        self.assertEqual(dog.breed, 'Pug')
-        self.assertIsInstance(dog.owner, Person)
-        self.assertNotEqual(dog.owner.id, None)
+        assert dog.breed == 'Pug'
+        assert isinstance(dog.owner, Person)
+        assert dog.owner.id
 
         dog = mommy.prepare_recipe('tests.generic.dog')
-        self.assertEqual(dog.breed, 'Pug')
-        self.assertIsInstance(dog.owner, Person)
-        self.assertIsNone(dog.owner.id)
+        assert dog.breed == 'Pug'
+        assert isinstance(dog.owner, Person)
+        assert dog.owner.id is None
 
         dog = mommy.prepare_recipe('tests.generic.dog', _save_related=True)
-        self.assertEqual(dog.breed, 'Pug')
-        self.assertIsInstance(dog.owner, Person)
-        self.assertIsNotNone(dog.owner.id)
+        assert dog.breed == 'Pug'
+        assert isinstance(dog.owner, Person)
+        assert dog.owner.id
 
         dogs = mommy.make_recipe('tests.generic.dog', _quantity=2)
         owner = dogs[0].owner
         for dog in dogs:
-            self.assertEqual(dog.breed, 'Pug')
-            self.assertEqual(dog.owner, owner)
+            assert dog.breed == 'Pug'
+            assert dog.owner == owner
 
     def test_model_with_foreign_key_as_str(self):
         dog = mommy.make_recipe('tests.generic.other_dog')
-        self.assertEqual(dog.breed, 'Basset')
-        self.assertIsInstance(dog.owner, Person)
-        self.assertNotEqual(dog.owner.id, None)
+        assert dog.breed == 'Basset'
+        assert isinstance(dog.owner, Person)
+        assert dog.owner.id
 
         dog = mommy.prepare_recipe('tests.generic.other_dog')
-        self.assertEqual(dog.breed, 'Basset')
-        self.assertIsInstance(dog.owner, Person)
-        self.assertIsNone(dog.owner.id)
+        assert dog.breed == 'Basset'
+        assert isinstance(dog.owner, Person)
+        assert dog.owner.id is None
 
     def test_model_with_foreign_key_as_unicode(self):
         dog = mommy.make_recipe('tests.generic.other_dog_unicode')
-        self.assertEqual(dog.breed, 'Basset')
-        self.assertIsInstance(dog.owner, Person)
-        self.assertNotEqual(dog.owner.id, None)
+        assert dog.breed == 'Basset'
+        assert isinstance(dog.owner, Person)
+        assert dog.owner.id
 
         dog = mommy.prepare_recipe('tests.generic.other_dog_unicode')
-        self.assertEqual(dog.breed, 'Basset')
-        self.assertIsInstance(dog.owner, Person)
-        self.assertIsNone(dog.owner.id)
+        assert dog.breed == 'Basset'
+        assert isinstance(dog.owner, Person)
+        assert dog.owner.id is None
 
     def test_make_recipe(self):
         person = mommy.make_recipe('tests.generic.person')
-        self.assertIsInstance(person, Person)
-        self.assertNotEqual(person.id, None)
+        assert isinstance(person, Person)
+        assert person.id
 
     def test_make_recipe_with_quantity_parameter(self):
         people = mommy.make_recipe('tests.generic.person', _quantity=3)
-        self.assertEqual(len(people), 3)
+        assert len(people) == 3
         for person in people:
-            self.assertIsInstance(person, Person)
-            self.assertNotEqual(person.id, None)
+            assert isinstance(person, Person)
+            assert person.id
 
     def test_make_extended_recipe(self):
         extended_dog = mommy.make_recipe('tests.generic.extended_dog')
-        self.assertEqual(extended_dog.breed, 'Super basset')
+        assert extended_dog.breed == 'Super basset'
         # No side effects happened due to extension
         base_dog = mommy.make_recipe('tests.generic.dog')
-        self.assertEqual(base_dog.breed, 'Pug')
+        assert base_dog.breed == 'Pug'
 
     def test_extended_recipe_type(self):
-        self.assertIsInstance(pug, SmallDogRecipe)
+        assert isinstance(pug, SmallDogRecipe)
 
     def test_save_related_instances_on_prepare_recipe(self):
         dog = mommy.prepare_recipe('tests.generic.homeless_dog')
-        self.assertIsNone(dog.id)
-        self.assertIsNone(dog.owner.id)
+        assert not dog.id
+        assert not dog.owner.id
 
         dog = mommy.prepare_recipe('tests.generic.homeless_dog', _save_related=True)
-        self.assertIsNone(dog.id)
-        self.assertTrue(dog.owner.id)
+        assert not dog.id
+        assert dog.owner.id
 
     def test_make_recipe_with_quantity_parameter_respection_model_args(self):
         people = mommy.make_recipe(
@@ -261,20 +259,16 @@ class TestExecutingRecipes(TestCase):
             name='Dennis Ritchie',
             age=70
         )
-        self.assertEqual(len(people), 3)
+        assert len(people) == 3
         for person in people:
-            self.assertEqual(person.name, 'Dennis Ritchie')
-            self.assertEqual(person.age, 70)
+            assert person.name == 'Dennis Ritchie'
+            assert person.age == 70
 
     def test_make_recipe_raises_correct_exception_if_invalid_quantity(self):
-        self.assertRaises(
-            InvalidQuantityException,
-            mommy.make_recipe, 'tests.generic.person', _quantity="hi"
-        )
-        self.assertRaises(
-            InvalidQuantityException,
-            mommy.make_recipe, 'tests.generic.person', _quantity=-1
-        )
+        with pytest.raises(InvalidQuantityException):
+            mommy.make_recipe('tests.generic.person', _quantity="hi")
+        with pytest.raises(InvalidQuantityException):
+            mommy.make_recipe('tests.generic.person', _quantity=-1)
 
     def test_prepare_recipe_with_foreign_key(self):
         person_recipe = Recipe(Person, name='John Doe')
@@ -284,15 +278,15 @@ class TestExecutingRecipes(TestCase):
         )
         dog = dog_recipe.prepare()
 
-        self.assertIsNone(dog.id)
-        self.assertIsNone(dog.owner.id)
+        assert dog.id is None
+        assert dog.owner.id is None
 
     def test_prepare_recipe_with_quantity_parameter(self):
         people = mommy.prepare_recipe('tests.generic.person', _quantity=3)
-        self.assertEqual(len(people), 3)
+        assert len(people) == 3
         for person in people:
-            self.assertIsInstance(person, Person)
-            self.assertEqual(person.id, None)
+            assert isinstance(person, Person)
+            assert person.id == None
 
     def test_prepare_recipe_with_quantity_parameter_respection_model_args(self):
         people = mommy.prepare_recipe(
@@ -301,62 +295,60 @@ class TestExecutingRecipes(TestCase):
             name='Dennis Ritchie',
             age=70
         )
-        self.assertEqual(len(people), 3)
+        assert len(people) == 3
         for person in people:
-            self.assertEqual(person.name, 'Dennis Ritchie')
-            self.assertEqual(person.age, 70)
+            assert person.name == 'Dennis Ritchie'
+            assert person.age == 70
 
     def test_prepare_recipe_raises_correct_exception_if_invalid_quantity(self):
-        self.assertRaises(
-            InvalidQuantityException,
-            mommy.prepare_recipe, 'tests.generic.person', _quantity="hi"
-        )
-        self.assertRaises(
-            InvalidQuantityException,
-            mommy.prepare_recipe, 'tests.generic.person', _quantity=-1
-        )
+        with pytest.raises(InvalidQuantityException):
+            mommy.prepare_recipe('tests.generic.person', _quantity="hi")
+        with pytest.raises(InvalidQuantityException):
+            mommy.prepare_recipe('tests.generic.person', _quantity=-1)
 
     def test_prepare_recipe(self):
         person = mommy.prepare_recipe('tests.generic.person')
-        self.assertIsInstance(person, Person)
-        self.assertEqual(person.id, None)
+        assert isinstance(person, Person)
+        assert not person.id
 
     def test_make_recipe_with_args(self):
         person = mommy.make_recipe('tests.generic.person', name='Dennis Ritchie', age=70)
-        self.assertEqual(person.name, 'Dennis Ritchie')
-        self.assertEqual(person.age, 70)
+        assert person.name == 'Dennis Ritchie'
+        assert person.age == 70
 
     def test_prepare_recipe_with_args(self):
         person = mommy.prepare_recipe('tests.generic.person', name='Dennis Ritchie', age=70)
-        self.assertEqual(person.name, 'Dennis Ritchie')
-        self.assertEqual(person.age, 70)
+        assert person.name == 'Dennis Ritchie'
+        assert person.age == 70
 
     def test_import_recipe_inside_deeper_modules(self):
         recipe_name = 'tests.generic.tests.sub_package.person'
         person = mommy.prepare_recipe(recipe_name)
-        self.assertEqual(person.name, 'John Deeper')
+        assert person.name == 'John Deeper'
 
     def test_pass_save_kwargs(self):
         owner = mommy.make(Person)
 
         dog = mommy.make_recipe('tests.generic.overrided_save', _save_kwargs={'owner': owner})
-        self.assertEqual(owner, dog.owner)
+        assert owner == dog.owner
 
 
-class ForeignKeyTestCase(TestCase):
+@pytest.mark.django_db
+class TestForeignKey():
+
     def test_foreign_key_method_returns_a_recipe_foreign_key_object(self):
         number_recipe = Recipe(
             DummyNumbersModel,
             float_field=1.6
         )
         obj = foreign_key(number_recipe)
-        self.assertIsInstance(obj, RecipeForeignKey)
+        assert isinstance(obj, RecipeForeignKey)
 
     def test_not_accept_other_type(self):
-        with self.assertRaises(TypeError) as c:
+        with pytest.raises(TypeError) as c:
             foreign_key(2)
-        exception = c.exception
-        self.assertEqual(str(exception), 'Not a recipe')
+        exception = c.value
+        assert str(exception) == 'Not a recipe'
 
     def test_do_not_create_related_model(self):
         """
@@ -364,11 +356,11 @@ class ForeignKeyTestCase(TestCase):
           passing the object as argument
         """
         person = mommy.make_recipe('tests.generic.person')
-        self.assertEqual(Person.objects.count(), 1)
+        assert Person.objects.count() == 1
         mommy.make_recipe('tests.generic.dog', owner=person)
-        self.assertEqual(Person.objects.count(), 1)
+        assert Person.objects.count() == 1
         mommy.prepare_recipe('tests.generic.dog', owner=person)
-        self.assertEqual(Person.objects.count(), 1)
+        assert Person.objects.count() == 1
 
     def test_do_query_lookup_for_recipes_make_method(self):
         """
@@ -376,8 +368,8 @@ class ForeignKeyTestCase(TestCase):
           using query lookup syntax
         """
         dog = mommy.make_recipe('tests.generic.dog', owner__name='James')
-        self.assertEqual(Person.objects.count(), 1)
-        self.assertEqual(dog.owner.name, 'James')
+        assert Person.objects.count() == 1
+        assert dog.owner.name == 'James'
 
     def test_do_query_lookup_for_recipes_prepare_method(self):
         """
@@ -385,7 +377,7 @@ class ForeignKeyTestCase(TestCase):
           using query lookup syntax
         """
         dog = mommy.prepare_recipe('tests.generic.dog', owner__name='James')
-        self.assertEqual(dog.owner.name, 'James')
+        assert dog.owner.name == 'James'
 
     def test_do_query_lookup_empty_recipes(self):
         """
@@ -394,155 +386,161 @@ class ForeignKeyTestCase(TestCase):
         """
         dog_recipe = Recipe(Dog)
         dog = dog_recipe.make(owner__name='James')
-        self.assertEqual(Person.objects.count(), 1)
-        self.assertEqual(dog.owner.name, 'James')
+        assert Person.objects.count() == 1
+        assert dog.owner.name == 'James'
 
         dog = dog_recipe.prepare(owner__name='Zezin')
-        self.assertEqual(Person.objects.count(), 1)
-        self.assertEqual(dog.owner.name, 'Zezin')
+        assert Person.objects.count() == 1
+        assert dog.owner.name == 'Zezin'
 
     def test_related_models_recipes(self):
         lady = mommy.make_recipe('tests.generic.dog_lady')
-        self.assertEqual(lady.dog_set.count(), 2)
-        self.assertEqual(lady.dog_set.all()[0].breed, 'Pug')
-        self.assertEqual(lady.dog_set.all()[1].breed, 'Basset')
+        assert lady.dog_set.count() == 2
+        assert lady.dog_set.all()[0].breed == 'Pug'
+        assert lady.dog_set.all()[1].breed == 'Basset'
 
     def test_nullable_related(self):
         nullable = mommy.make_recipe('tests.generic.nullable_related')
-        self.assertEqual(nullable.dummynullfieldsmodel_set.count(), 1)
+        assert nullable.dummynullfieldsmodel_set.count() == 1
 
     def test_chained_related(self):
         movie = mommy.make_recipe('tests.generic.movie_with_cast')
-        self.assertEqual(movie.cast_members.count(), 2)
+        assert movie.cast_members.count() == 2
 
 
-class M2MFieldTestCase(TestCase):
+@pytest.mark.django_db
+class TestM2MField():
+
     def test_create_many_to_many(self):
         dog = mommy.make_recipe('tests.generic.dog_with_friends')
-        self.assertEqual(len(dog.friends_with.all()), 2)
+        assert len(dog.friends_with.all()) == 2
         for friend in dog.friends_with.all():
-            self.assertEqual(friend.breed, 'Pug')
-            self.assertEqual(friend.owner.name, 'John Doe')
+            assert friend.breed == 'Pug'
+            assert friend.owner.name == 'John Doe'
 
     def test_create_nested(self):
         dog = mommy.make_recipe('tests.generic.dog_with_more_friends')
-        self.assertEqual(len(dog.friends_with.all()), 1)
+        assert len(dog.friends_with.all()) == 1
         friend = dog.friends_with.all()[0]
-        self.assertEqual(len(friend.friends_with.all()), 2)
+        assert len(friend.friends_with.all()) == 2
 
 
-class TestSequences(TestCase):
+@pytest.mark.django_db
+class TestSequences():
+
     def test_increment_for_strings(self):
         person = mommy.make_recipe('tests.generic.serial_person')
-        self.assertEqual(person.name, 'joe1')
+        assert person.name == 'joe1'
         person = mommy.prepare_recipe('tests.generic.serial_person')
-        self.assertEqual(person.name, 'joe2')
+        assert person.name == 'joe2'
         person = mommy.make_recipe('tests.generic.serial_person')
-        self.assertEqual(person.name, 'joe3')
+        assert person.name == 'joe3'
 
     def test_increment_for_numbers(self):
         dummy = mommy.make_recipe('tests.generic.serial_numbers')
-        self.assertEqual(dummy.default_int_field, 11)
-        self.assertEqual(dummy.default_decimal_field, Decimal('21.1'))
-        self.assertEqual(dummy.default_float_field, 2.23)
+        assert dummy.default_int_field == 11
+        assert dummy.default_decimal_field == Decimal('21.1')
+        assert dummy.default_float_field == 2.23
         dummy = mommy.make_recipe('tests.generic.serial_numbers')
-        self.assertEqual(dummy.default_int_field, 12)
-        self.assertEqual(dummy.default_decimal_field, Decimal('22.1'))
-        self.assertEqual(dummy.default_float_field, 3.23)
+        assert dummy.default_int_field == 12
+        assert dummy.default_decimal_field == Decimal('22.1')
+        assert dummy.default_float_field == 3.23
         dummy = mommy.prepare_recipe('tests.generic.serial_numbers')
-        self.assertEqual(dummy.default_int_field, 13)
-        self.assertEqual(dummy.default_decimal_field, Decimal('23.1'))
-        self.assertEqual(dummy.default_float_field, 4.23)
+        assert dummy.default_int_field == 13
+        assert dummy.default_decimal_field == Decimal('23.1')
+        assert dummy.default_float_field == 4.23
 
     def test_increment_for_numbers_2(self):
         """
         This test is a repeated one but it is necessary to ensure Sequences atomicity
         """
         dummy = mommy.make_recipe('tests.generic.serial_numbers')
-        self.assertEqual(dummy.default_int_field, 11)
-        self.assertEqual(dummy.default_decimal_field, Decimal('21.1'))
-        self.assertEqual(dummy.default_float_field, 2.23)
+        assert dummy.default_int_field == 11
+        assert dummy.default_decimal_field == Decimal('21.1')
+        assert dummy.default_float_field == 2.23
         dummy = mommy.make_recipe('tests.generic.serial_numbers')
-        self.assertEqual(dummy.default_int_field, 12)
-        self.assertEqual(dummy.default_decimal_field, Decimal('22.1'))
-        self.assertEqual(dummy.default_float_field, 3.23)
+        assert dummy.default_int_field == 12
+        assert dummy.default_decimal_field == Decimal('22.1')
+        assert dummy.default_float_field == 3.23
         dummy = mommy.prepare_recipe('tests.generic.serial_numbers')
-        self.assertEqual(dummy.default_int_field, 13)
-        self.assertEqual(dummy.default_decimal_field, Decimal('23.1'))
-        self.assertEqual(dummy.default_float_field, 4.23)
+        assert dummy.default_int_field == 13
+        assert dummy.default_decimal_field == Decimal('23.1')
+        assert dummy.default_float_field == 4.23
 
     def test_creates_unique_field_recipe_using_for_iterator(self):
         for i in range(1, 4):
             dummy = mommy.make_recipe('tests.generic.dummy_unique_field')
-            self.assertEqual(dummy.value, 10 + i)
+            assert dummy.value == 10 + i
 
     def test_creates_unique_field_recipe_using_quantity_argument(self):
         dummies = mommy.make_recipe('tests.generic.dummy_unique_field', _quantity=3)
-        self.assertEqual(11, dummies[0].value)
-        self.assertEqual(12, dummies[1].value)
-        self.assertEqual(13, dummies[2].value)
+        assert 11 == dummies[0].value
+        assert 12 == dummies[1].value
+        assert 13 == dummies[2].value
 
     def test_increment_by_3(self):
         dummy = mommy.make_recipe('tests.generic.serial_numbers_by')
-        self.assertEqual(dummy.default_int_field, 13)
-        self.assertEqual(dummy.default_decimal_field, Decimal('22.5'))
-        self.assertAlmostEqual(dummy.default_float_field, 3.030000)
+        assert dummy.default_int_field == 13
+        assert dummy.default_decimal_field == Decimal('22.5')
+        assert dummy.default_float_field == pytest.approx(3.030000)
         dummy = mommy.make_recipe('tests.generic.serial_numbers_by')
-        self.assertEqual(dummy.default_int_field, 16)
-        self.assertEqual(dummy.default_decimal_field, Decimal('24.9'))
-        self.assertAlmostEqual(dummy.default_float_field, 4.83)
+        assert dummy.default_int_field == 16
+        assert dummy.default_decimal_field == Decimal('24.9')
+        assert dummy.default_float_field == pytest.approx(4.83)
         dummy = mommy.prepare_recipe('tests.generic.serial_numbers_by')
-        self.assertEqual(dummy.default_int_field, 19)
-        self.assertEqual(dummy.default_decimal_field, Decimal('27.3'))
-        self.assertAlmostEqual(dummy.default_float_field, 6.63)
+        assert dummy.default_int_field == 19
+        assert dummy.default_decimal_field == Decimal('27.3')
+        assert dummy.default_float_field == pytest.approx(6.63)
 
     def test_increment_by_timedelta(self):
         dummy = mommy.make_recipe('tests.generic.serial_datetime')
-        self.assertEqual(dummy.default_date_field, (TEST_TIME.date() + timedelta(days=1)))
-        self.assertEqual(dummy.default_date_time_field, tz_aware(TEST_TIME + timedelta(hours=3)))
-        self.assertEqual(dummy.default_time_field, (TEST_TIME + timedelta(seconds=15)).time())
+        assert dummy.default_date_field == (TEST_TIME.date() + timedelta(days=1))
+        assert dummy.default_date_time_field == tz_aware(TEST_TIME + timedelta(hours=3))
+        assert dummy.default_time_field == (TEST_TIME + timedelta(seconds=15)).time()
         dummy = mommy.make_recipe('tests.generic.serial_datetime')
-        self.assertEqual(dummy.default_date_field, (TEST_TIME.date() + timedelta(days=2)))
-        self.assertEqual(dummy.default_date_time_field, tz_aware(TEST_TIME + timedelta(hours=6)))
-        self.assertEqual(dummy.default_time_field, (TEST_TIME + timedelta(seconds=30)).time())
+        assert dummy.default_date_field == (TEST_TIME.date() + timedelta(days=2))
+        assert dummy.default_date_time_field == tz_aware(TEST_TIME + timedelta(hours=6))
+        assert dummy.default_time_field == (TEST_TIME + timedelta(seconds=30)).time()
 
     def test_creates_unique_timedelta_recipe_using_quantity_argument(self):
         dummies = mommy.make_recipe('tests.generic.serial_datetime', _quantity=3)
-        self.assertEqual(dummies[0].default_date_field, TEST_TIME.date() + timedelta(days=1))
-        self.assertEqual(dummies[1].default_date_field, TEST_TIME.date() + timedelta(days=2))
-        self.assertEqual(dummies[2].default_date_field, TEST_TIME.date() + timedelta(days=3))
+        assert dummies[0].default_date_field == TEST_TIME.date() + timedelta(days=1)
+        assert dummies[1].default_date_field == TEST_TIME.date() + timedelta(days=2)
+        assert dummies[2].default_date_field == TEST_TIME.date() + timedelta(days=3)
 
     def test_increment_after_override_definition_field(self):
         person = mommy.make_recipe('tests.generic.serial_person', name='tom')
-        self.assertEqual(person.name, 'tom')
+        assert person.name == 'tom'
         person = mommy.make_recipe('tests.generic.serial_person')
-        self.assertEqual(person.name, 'joe1')
+        assert person.name == 'joe4'
         person = mommy.prepare_recipe('tests.generic.serial_person')
-        self.assertEqual(person.name, 'joe2')
+        assert person.name == 'joe5'
 
 
-class TestIterators(TestCase):
+@pytest.mark.django_db
+class TestIterators():
 
     def test_accepts_generators(self):
         r = Recipe(DummyBlankFieldsModel,
                    blank_char_field=itertools.cycle(['a', 'b']))
-        self.assertEqual('a', r.make().blank_char_field)
-        self.assertEqual('b', r.make().blank_char_field)
-        self.assertEqual('a', r.make().blank_char_field)
+        assert 'a' == r.make().blank_char_field
+        assert 'b' == r.make().blank_char_field
+        assert 'a' == r.make().blank_char_field
 
     def test_accepts_iterators(self):
         r = Recipe(DummyBlankFieldsModel,
                    blank_char_field=iter(['a', 'b', 'c']))
-        self.assertEqual('a', r.make().blank_char_field)
-        self.assertEqual('b', r.make().blank_char_field)
-        self.assertEqual('c', r.make().blank_char_field)
+        assert 'a' == r.make().blank_char_field
+        assert 'b' == r.make().blank_char_field
+        assert 'c' == r.make().blank_char_field
 
     def test_empty_iterator_exception(self):
         r = Recipe(DummyBlankFieldsModel,
                    blank_char_field=iter(['a', 'b']))
-        self.assertEqual('a', r.make().blank_char_field)
-        self.assertEqual('b', r.make().blank_char_field)
-        self.assertRaises(RecipeIteratorEmpty, r.make)
+        assert 'a' == r.make().blank_char_field
+        assert 'b' == r.make().blank_char_field
+        with pytest.raises(RecipeIteratorEmpty):
+            r.make()
 
     def test_only_iterators_not_iteratables_are_iterated(self):
         """Ensure we only iterate explicit iterators.
@@ -555,6 +553,4 @@ class TestIterators(TestCase):
         """
         r = Recipe(DummyBlankFieldsModel,
                    blank_text_field="not an iterator, so don't iterate!")
-        self.assertEqual(
-            r.make().blank_text_field,
-            "not an iterator, so don't iterate!")
+        assert r.make().blank_text_field == "not an iterator, so don't iterate!"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,23 +1,26 @@
-from django.test import TestCase
+import pytest
 
-from model_mommy.utils import import_if_str
+from model_mommy.utils import import_if_str, import_from_str
 
 from tests.generic.models import User
 
 
-class TestUtils(TestCase):
-
+class TestUtils:
     def test_import_from_str(self):
-        self.assertRaises(AttributeError,
-                          import_if_str, 'tests.generic.UndefinedObject')
-        self.assertRaises(ImportError,
-                          import_if_str, 'tests.generic.undefined_path.User')
-        self.assertEqual(User, import_if_str('tests.generic.models.User'))
+        with pytest.raises(AttributeError):
+            import_from_str('tests.generic.UndefinedObject')
+
+        with pytest.raises(ImportError):
+            import_from_str('tests.generic.undefined_path.User')
+
+        assert import_from_str('tests.generic.models.User') == User
 
     def test_import_if_str(self):
-        self.assertRaises(AttributeError,
-                          import_if_str, 'tests.generic.UndefinedObject')
-        self.assertRaises(ImportError,
-                          import_if_str, 'tests.generic.undefined_path.User')
-        self.assertEqual(User, import_if_str('tests.generic.models.User'))
-        self.assertEqual(User, import_if_str(User))
+        with pytest.raises(AttributeError):
+            import_if_str('tests.generic.UndefinedObject')
+
+        with pytest.raises(ImportError):
+            import_if_str('tests.generic.undefined_path.User')
+
+        assert import_if_str('tests.generic.models.User') == User
+        assert import_if_str(User) == User


### PR DESCRIPTION
Since we switched to pytest in #395, it is time to use it with full force!

ToDo:
- [x] tests/test_extending_mommy.py
- [x] tests/test_filling_fields.py
- [x] tests/test_mommy.py
- [x] tests/test_recipes.py
- [x] tests/test_utils.py