### PR TITLE
Remove obsolete field imports in tests

### DIFF
--- a/tests/generic/models.py
+++ b/tests/generic/models.py
@@ -75,56 +75,22 @@ class Person(models.Model):
     appointment = models.DateTimeField()
     blog = models.URLField()
     occupation = models.CharField(max_length=10, choices=OCCUPATION_CHOCIES)
-    try:
-        uuid = models.UUIDField(primary_key=False)
-    except AttributeError:
-        # New at Django 1.9
-        pass
-    try:
-        name_hash = models.BinaryField(max_length=16)
-    except AttributeError:
-        # We can't test the binary field if it is not supported
-        # (django < 1,6)
-        pass
-    try:
-        from django.contrib.postgres.fields import ArrayField
-        acquaintances = ArrayField(models.IntegerField())
-    except ImportError:
-        # New at Django 1.9
-        pass
+    uuid = models.UUIDField(primary_key=False)
+    name_hash = models.BinaryField(max_length=16)
+    wanted_games_qtd = models.BigIntegerField()
+    duration_of_sleep = models.DurationField()
 
     try:
-        from django.contrib.postgres.fields import JSONField
-        data = JSONField()
-    except ImportError:
-        # New at Django 1.9
-        pass
-
-    try:
-        from django.contrib.postgres.fields import HStoreField
-        hstore_data = HStoreField()
-    except ImportError:
-        # New at Django 1.8
-        pass
-
-    # backward compatibility with Django 1.1
-    try:
-        wanted_games_qtd = models.BigIntegerField()
-    except AttributeError:
-        wanted_games_qtd = models.IntegerField()
-
-    try:
+        from django.contrib.postgres.fields import ArrayField, HStoreField, JSONField
         from django.contrib.postgres.fields.citext import CICharField, CIEmailField, CITextField
+        acquaintances = ArrayField(models.IntegerField())
+        data = JSONField()
+        hstore_data = HStoreField()
         ci_char = CICharField(max_length=30)
         ci_email = CIEmailField()
         ci_text = CITextField()
     except ImportError:
-        # New at Django 1.11
-        pass
-
-    try:
-        duration_of_sleep = models.DurationField()
-    except AttributeError:
+        # Skip PostgreSQL-related fields
         pass
 
     if MOMMY_GIS:
@@ -187,10 +153,7 @@ class DummyEmptyModel(models.Model):
 class DummyIntModel(models.Model):
     int_field = models.IntegerField()
     small_int_field = models.SmallIntegerField()
-    try:
-        big_int_field = models.BigIntegerField()
-    except AttributeError:
-        big_int_field = models.IntegerField()
+    big_int_field = models.BigIntegerField()
 
 
 class DummyPositiveIntModel(models.Model):

--- a/tests/test_filling_fields.py
+++ b/tests/test_filling_fields.py
@@ -1,87 +1,39 @@
+import uuid
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from os.path import abspath
 from tempfile import gettempdir
 from unittest import skipUnless
 
+import pytest
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.files import File
-from django.core.files.images import ImageFile
-from django.db import models as django_models
+from django.core.files import images, File
+from django.db import connection
+from django.db.models import fields, ImageField, FileField
 from django.test import TestCase
 
 from model_mommy import mommy
 from model_mommy.gis import MOMMY_GIS
 from model_mommy.random_gen import gen_related
-from tests.generic import models
-from tests.generic.generators import gen_value_string
+from tests.generic import generators, models
+
 
 try:
-    from django.db.models.fields import GenericIPAddressField
-except ImportError:
-    GenericIPAddressField = django_models.IPAddressField
-
-try:
-    from django.db.models.fields import BigIntegerField
-except ImportError:
-    pass
-
-try:
-    from django.db.models.fields import BinaryField
-except ImportError:
-    BinaryField = None
-
-try:
-    from django.db.models.fields import DurationField
-except ImportError:
-    DurationField = None
-
-try:
-    from django.db.models.fields import UUIDField
-except ImportError:
-    UUIDField = None
-
-try:
-    from django.contrib.postgres.fields import ArrayField
+    from django.contrib.postgres.fields import (
+        ArrayField, CICharField, CIEmailField, CITextField, HStoreField, JSONField,
+    )
 except ImportError:
     ArrayField = None
-
-try:
-    from django.contrib.postgres.fields import JSONField
-except ImportError:
     JSONField = None
-
-try:
-    from django.contrib.postgres.fields import HStoreField
-except ImportError:
     HStoreField = None
-
-try:
-    from django.contrib.postgres.fields.citext import CICharField, CIEmailField, CITextField
-except ImportError:
     CICharField = None
     CIEmailField = None
     CITextField = None
 
-from django.core.validators import validate_ipv4_address
-
-from django.core.validators import validate_ipv6_address, validate_ipv46_address
-
-
-__all__ = [
-    'StringFieldsFilling', 'BooleanFieldsFilling', 'DateTimeFieldsFilling',
-    'DateFieldsFilling', 'FillingIntFields', 'FillingPositiveIntFields',
-    'FillingOthersNumericFields', 'FillingFromChoice', 'URLFieldsFilling',
-    'FillingEmailField', 'FillingIPAddressField', 'FillingGenericForeignKeyField',
-    'FillingFileField', 'FillingImageFileField', 'TimeFieldsFilling', 'FillingCustomFields',
-]
-
-if BinaryField:
-    __all__.append('BinaryFieldsFilling')
-
-if DurationField:
-    __all__.append('DurationField')
+from django.core.validators import (
+    validate_ipv4_address, validate_ipv6_address, validate_ipv46_address
+)
 
 
 def assert_not_raise(method, parameters, exception):
@@ -90,6 +42,11 @@ def assert_not_raise(method, parameters, exception):
     except exception:
         msg = "Exception %s not expected to be raised" % exception.__name__
         raise AssertionError(msg)
+
+
+@pytest.fixture
+def person(db):
+    return mommy.make('generic.Person')
 
 
 class FieldFillingTestCase(TestCase):
@@ -114,14 +71,14 @@ class StringFieldsFilling(FieldFillingTestCase):
 
     def test_fill_CharField_with_a_random_str(self):
         person_name_field = models.Person._meta.get_field('name')
-        self.assertIsInstance(person_name_field, django_models.CharField)
+        self.assertIsInstance(person_name_field, fields.CharField)
 
         self.assertIsInstance(self.person.name, str)
         self.assertEqual(len(self.person.name), person_name_field.max_length)
 
     def test_fill_SlugField_with_a_random_str(self):
         person_nickname_field = models.Person._meta.get_field('nickname')
-        self.assertIsInstance(person_nickname_field, django_models.SlugField)
+        self.assertIsInstance(person_nickname_field, fields.SlugField)
 
         self.assertIsInstance(self.person.nickname, str)
         self.assertEqual(len(self.person.nickname),
@@ -129,64 +86,58 @@ class StringFieldsFilling(FieldFillingTestCase):
 
     def test_fill_TextField_with_a_random_str(self):
         person_bio_field = models.Person._meta.get_field('bio')
-        self.assertIsInstance(person_bio_field, django_models.TextField)
+        self.assertIsInstance(person_bio_field, fields.TextField)
 
         self.assertIsInstance(self.person.bio, str)
 
 
-class CIStringFieldsFilling(FieldFillingTestCase):
+@pytest.mark.skipif(connection.vendor != 'postgresql', reason='PostgreSQL specific tests')
+class TestCIStringFieldsFilling:
+    def test_fill_cicharfield_with_a_random_str(self, person):
+        ci_char_field = models.Person._meta.get_field('ci_char')
+        assert isinstance(ci_char_field, CICharField)
+        assert isinstance(person.ci_char, str)
+        assert len(person.ci_char) == ci_char_field.max_length
 
-    if CICharField:
-        def test_fill_CICharField_with_a_random_str(self):
-            ci_char_field = models.Person._meta.get_field('ci_char')
-            self.assertIsInstance(ci_char_field, CICharField)
+    def test_filling_ciemailfield(self, person):
+        ci_email_field = models.Person._meta.get_field('ci_email')
+        assert isinstance(ci_email_field, CIEmailField)
+        assert isinstance(person.ci_email, str)
 
-            self.assertIsInstance(self.person.ci_char, str)
-            self.assertEqual(len(self.person.ci_char), ci_char_field.max_length)
-
-    if CIEmailField:
-        def test_filling_CIEmailField(self):
-            ci_email_field = models.Person._meta.get_field('ci_email')
-            self.assertIsInstance(ci_email_field, CIEmailField)
-            self.assertIsInstance(self.person.ci_email, str)
-
-    if CITextField:
-        def test_filling_CITextField(self):
-            ci_text_field = models.Person._meta.get_field('ci_text')
-            self.assertIsInstance(ci_text_field, CITextField)
-            self.assertIsInstance(self.person.ci_text, str)
+    def test_filling_citextfield(self, person):
+        ci_text_field = models.Person._meta.get_field('ci_text')
+        assert isinstance(ci_text_field, CITextField)
+        assert isinstance(person.ci_text, str)
 
 
 class BinaryFieldsFilling(FieldFillingTestCase):
-    if BinaryField:
-        def test_fill_BinaryField_with_random_binary(self):
-            name_hash_field = models.Person._meta.get_field('name_hash')
-            self.assertIsInstance(name_hash_field, BinaryField)
-            name_hash = self.person.name_hash
-            self.assertIsInstance(name_hash, bytes)
-            self.assertEqual(len(name_hash), name_hash_field.max_length)
+    def test_fill_BinaryField_with_random_binary(self):
+        name_hash_field = models.Person._meta.get_field('name_hash')
+        self.assertIsInstance(name_hash_field, fields.BinaryField)
+        name_hash = self.person.name_hash
+        self.assertIsInstance(name_hash, bytes)
+        self.assertEqual(len(name_hash), name_hash_field.max_length)
 
 
 class DurationFieldsFilling(FieldFillingTestCase):
-    if DurationField:
-        def test_fill_DurationField_with_random_interval_in_miliseconds(self):
-            duration_of_sleep_field = models.Person._meta.get_field('duration_of_sleep')
-            self.assertIsInstance(duration_of_sleep_field, DurationField)
-            duration_of_sleep = self.person.duration_of_sleep
-            self.assertIsInstance(duration_of_sleep, timedelta)
+    def test_fill_DurationField_with_random_interval_in_miliseconds(self):
+        duration_of_sleep_field = models.Person._meta.get_field('duration_of_sleep')
+        self.assertIsInstance(duration_of_sleep_field, fields.DurationField)
+        duration_of_sleep = self.person.duration_of_sleep
+        self.assertIsInstance(duration_of_sleep, timedelta)
 
 
 class BooleanFieldsFilling(FieldFillingTestCase):
     def test_fill_BooleanField_with_boolean(self):
         happy_field = models.Person._meta.get_field('happy')
-        self.assertIsInstance(happy_field, django_models.BooleanField)
+        self.assertIsInstance(happy_field, fields.BooleanField)
 
         self.assertIsInstance(self.person.happy, bool)
         self.assertTrue(self.person.happy)
 
     def test_fill_BooleanField_with_false_if_default_is_false(self):
         unhappy_field = models.Person._meta.get_field('unhappy')
-        self.assertIsInstance(unhappy_field, django_models.BooleanField)
+        self.assertIsInstance(unhappy_field, fields.BooleanField)
 
         self.assertIsInstance(self.person.unhappy, bool)
         self.assertFalse(self.person.unhappy)
@@ -196,7 +147,7 @@ class DateFieldsFilling(FieldFillingTestCase):
 
     def test_fill_DateField_with_a_date(self):
         birthday_field = models.Person._meta.get_field('birthday')
-        self.assertIsInstance(birthday_field, django_models.DateField)
+        self.assertIsInstance(birthday_field, fields.DateField)
         self.assertIsInstance(self.person.birthday, date)
 
 
@@ -204,7 +155,7 @@ class DateTimeFieldsFilling(FieldFillingTestCase):
 
     def test_fill_DateTimeField_with_a_datetime(self):
         appointment_field = models.Person._meta.get_field('appointment')
-        self.assertIsInstance(appointment_field, django_models.DateTimeField)
+        self.assertIsInstance(appointment_field, fields.DateTimeField)
         self.assertIsInstance(self.person.appointment, datetime)
 
 
@@ -212,37 +163,28 @@ class TimeFieldsFilling(FieldFillingTestCase):
 
     def test_fill_TimeField_with_a_time(self):
         birth_time_field = models.Person._meta.get_field('birth_time')
-        self.assertIsInstance(birth_time_field, django_models.TimeField)
+        self.assertIsInstance(birth_time_field, fields.TimeField)
         self.assertIsInstance(self.person.birth_time, time)
 
 
 class UUIDFieldsFilling(FieldFillingTestCase):
-    if UUIDField:
-        def test_fill_UUIDField_with_uuid_object(self):
-            import uuid
+    def test_fill_UUIDField_with_uuid_object(self):
+        uuid_field = models.Person._meta.get_field('uuid')
+        self.assertIsInstance(uuid_field, fields.UUIDField)
 
-            uuid_field = models.Person._meta.get_field('uuid')
-            self.assertIsInstance(uuid_field, UUIDField)
-
-            self.assertIsInstance(self.person.uuid, uuid.UUID)
+        self.assertIsInstance(self.person.uuid, uuid.UUID)
 
 
-class ArrayFieldsFilling(FieldFillingTestCase):
-    if ArrayField:
-        def test_fill_ArrayField_with_empty_array(self):
-            self.assertEqual(self.person.acquaintances, [])
+@pytest.mark.skipif(connection.vendor != 'postgresql', reason='PostgreSQL specific tests')
+class TestPostgreSQLFieldsFilling:
+    def test_fill_arrayfield_with_empty_array(self, person):
+        assert person.acquaintances == []
 
+    def test_fill_jsonfield_with_empty_dict(self, person):
+        assert person.data == {}
 
-class JSONFieldsFilling(FieldFillingTestCase):
-    if JSONField:
-        def test_fill_JSONField_with_empty_dict(self):
-            self.assertEqual(self.person.data, {})
-
-
-class HStoreFieldsFilling(FieldFillingTestCase):
-    if HStoreField:
-        def test_fill_HStoreField_with_empty_dict(self):
-            self.assertEqual(self.person.hstore_data, {})
+    def test_fill_hstorefield_with_empty_dict(self, person):
+        assert person.hstore_data == {}
 
 
 class FillingIntFields(TestCase):
@@ -252,17 +194,17 @@ class FillingIntFields(TestCase):
 
     def test_fill_IntegerField_with_a_random_number(self):
         int_field = models.DummyIntModel._meta.get_field('int_field')
-        self.assertIsInstance(int_field, django_models.IntegerField)
+        self.assertIsInstance(int_field, fields.IntegerField)
         self.assertIsInstance(self.dummy_int_model.int_field, int)
 
     def test_fill_BigIntegerField_with_a_random_number(self):
         big_int_field = models.DummyIntModel._meta.get_field('big_int_field')
-        self.assertIsInstance(big_int_field, BigIntegerField)
+        self.assertIsInstance(big_int_field, fields.BigIntegerField)
         self.assertIsInstance(self.dummy_int_model.big_int_field, int)
 
     def test_fill_SmallIntegerField_with_a_random_number(self):
         small_int_field = models.DummyIntModel._meta.get_field('small_int_field')
-        self.assertIsInstance(small_int_field, django_models.SmallIntegerField)
+        self.assertIsInstance(small_int_field, fields.SmallIntegerField)
         self.assertIsInstance(self.dummy_int_model.small_int_field, int)
 
 
@@ -274,13 +216,13 @@ class FillingPositiveIntFields(TestCase):
     def test_fill_PositiveSmallIntegerField_with_a_random_number(self):
         field = models.DummyPositiveIntModel._meta.get_field('positive_small_int_field')
         positive_small_int_field = field
-        self.assertIsInstance(positive_small_int_field, django_models.PositiveSmallIntegerField)
+        self.assertIsInstance(positive_small_int_field, fields.PositiveSmallIntegerField)
         self.assertIsInstance(self.dummy_positive_int_model.positive_small_int_field, int)
         self.assertTrue(self.dummy_positive_int_model.positive_small_int_field > 0)
 
     def test_fill_PositiveIntegerField_with_a_random_number(self):
         positive_int_field = models.DummyPositiveIntModel._meta.get_field('positive_int_field')
-        self.assertIsInstance(positive_int_field, django_models.PositiveIntegerField)
+        self.assertIsInstance(positive_int_field, fields.PositiveIntegerField)
         self.assertIsInstance(self.dummy_positive_int_model.positive_int_field, int)
         self.assertTrue(self.dummy_positive_int_model.positive_int_field > 0)
 
@@ -289,13 +231,13 @@ class FillingOthersNumericFields(TestCase):
     def test_filling_FloatField_with_a_random_float(self):
         self.dummy_numbers_model = mommy.make(models.DummyNumbersModel)
         float_field = models.DummyNumbersModel._meta.get_field('float_field')
-        self.assertIsInstance(float_field, django_models.FloatField)
+        self.assertIsInstance(float_field, fields.FloatField)
         self.assertIsInstance(self.dummy_numbers_model.float_field, float)
 
     def test_filling_DecimalField_with_random_decimal(self):
         self.dummy_decimal_model = mommy.make(models.DummyDecimalModel)
         decimal_field = models.DummyDecimalModel._meta.get_field('decimal_field')
-        self.assertIsInstance(decimal_field, django_models.DecimalField)
+        self.assertIsInstance(decimal_field, fields.DecimalField)
         self.assertIsInstance(self.dummy_decimal_model.decimal_field, Decimal)
 
 
@@ -303,7 +245,7 @@ class URLFieldsFilling(FieldFillingTestCase):
 
     def test_fill_URLField_with_valid_url(self):
         blog_field = models.Person._meta.get_field('blog')
-        self.assertIsInstance(blog_field, django_models.URLField)
+        self.assertIsInstance(blog_field, fields.URLField)
         self.assertIsInstance(self.person.blog, str)
 
 
@@ -312,21 +254,16 @@ class FillingEmailField(TestCase):
     def test_filling_EmailField(self):
         obj = mommy.make(models.DummyEmailModel)
         field = models.DummyEmailModel._meta.get_field('email_field')
-        self.assertIsInstance(field, django_models.EmailField)
+        self.assertIsInstance(field, fields.EmailField)
         self.assertIsInstance(obj.email_field, str)
 
 
 class FillingIPAddressField(TestCase):
 
     def test_filling_IPAddressField(self):
-        try:
-            from tests.generic.models import DummyGenericIPAddressFieldModel as IPModel
-        except ImportError:
-            from tests.generic.models import DummyIPAddressFieldModel as IPModel
-
-        obj = mommy.make(IPModel)
-        field = IPModel._meta.get_field('ipv4_field')
-        self.assertIsInstance(field, GenericIPAddressField)
+        obj = mommy.make(models.DummyGenericIPAddressFieldModel)
+        field = models.DummyGenericIPAddressFieldModel._meta.get_field('ipv4_field')
+        self.assertIsInstance(field, fields.GenericIPAddressField)
         self.assertIsInstance(obj.ipv4_field, str)
 
         validate_ipv4_address(obj.ipv4_field)
@@ -359,7 +296,7 @@ class FillingFileField(TestCase):
     def test_filling_file_field(self):
         self.dummy = mommy.make(models.DummyFileFieldModel, _create_files=True)
         field = models.DummyFileFieldModel._meta.get_field('file_field')
-        self.assertIsInstance(field, django_models.FileField)
+        self.assertIsInstance(field, FileField)
         import time
         path = "%s/%s/mock_file.txt" % (gettempdir(), time.strftime('%Y/%m/%d'))
 
@@ -376,7 +313,7 @@ class FillingImageFileField(TestCase):
 
     def setUp(self):
         path = mommy.mock_file_jpeg
-        self.fixture_img_file = ImageFile(open(path))
+        self.fixture_img_file = images.ImageFile(open(path))
 
     def tearDown(self):
         self.dummy.image_field.delete()
@@ -384,7 +321,7 @@ class FillingImageFileField(TestCase):
     def test_filling_image_file_field(self):
         self.dummy = mommy.make(models.DummyImageFieldModel, _create_files=True)
         field = models.DummyImageFieldModel._meta.get_field('image_field')
-        self.assertIsInstance(field, django_models.ImageField)
+        self.assertIsInstance(field, ImageField)
         import time
         path = "%s/%s/mock-img.jpeg" % (gettempdir(), time.strftime('%Y/%m/%d'))
 
@@ -413,7 +350,7 @@ class FillingCustomFields(TestCase):
 
     def test_uses_generator_defined_on_settings_for_custom_field(self):
         """Should use the function defined in settings as a generator"""
-        generator_dict = {'tests.generic.fields.CustomFieldWithGenerator': gen_value_string}
+        generator_dict = {'tests.generic.fields.CustomFieldWithGenerator': generators.gen_value_string}
         setattr(settings, 'MOMMY_CUSTOM_FIELDS_GEN', generator_dict)
         obj = mommy.make(models.CustomFieldWithGeneratorModel)
         self.assertEqual("value", obj.custom_value)
@@ -452,7 +389,7 @@ class FillingCustomFields(TestCase):
         obj = mommy.make(models.CustomForeignKeyWithGeneratorModel, custom_fk__email="a@b.com")
         self.assertEqual('a@b.com', obj.custom_fk.email)
 
-    def test_can_override_django_default_field_functions_genereator(self):
+    def test_can_override_django_default_field_functions_generator(self):
         def gen_char():
             return 'Some value'
 
@@ -468,7 +405,7 @@ class FillingAutoFields(TestCase):
     def test_filling_AutoField(self):
         obj = mommy.make(models.DummyEmptyModel)
         field = models.DummyEmptyModel._meta.get_field('id')
-        self.assertIsInstance(field, django_models.AutoField)
+        self.assertIsInstance(field, fields.AutoField)
         self.assertIsInstance(obj.id, int)
 
 


### PR DESCRIPTION
## Description
https://github.com/berinhard/model_mommy/pull/401 removed obsolete imports of old Django fields, but we still had leftovers in tests.

This PR cleans up import logic, related to BigIntegerField, BinaryField, UUIDField, DurationField, GenericIPAddressField and PostgreSQL-related fields.

## Testing
Green CI covers everything.